### PR TITLE
Fix Supabase initialization order in teacher console

### DIFF
--- a/public/js/teacher.js
+++ b/public/js/teacher.js
@@ -7,6 +7,14 @@ const sessionCodeEl = document.getElementById('sessionCode');
 const sessionUrlInput = document.getElementById('sessionUrl');
 const copyBtn = document.getElementById('copyBtn');
 
+let supabase;
+let channel;
+let channelReady = false;
+let sessionCode = '';
+let syncInterval = null;
+const presenceKey = `teacher-${Math.random().toString(36).slice(2, 10)}`;
+const students = new Map();
+
 const supabaseUrl = window.SUPABASE_URL;
 const supabaseAnonKey = window.SUPABASE_ANON_KEY;
 
@@ -18,14 +26,6 @@ if (!supabaseUrl || !supabaseAnonKey) {
         setStatusBadge('Something went wrong', 'error');
     });
 }
-
-let supabase;
-let channel;
-let channelReady = false;
-let sessionCode = '';
-let syncInterval = null;
-const presenceKey = `teacher-${Math.random().toString(36).slice(2, 10)}`;
-const students = new Map();
 
 async function initialiseTeacherConsole() {
     setStatusBadge('Connecting to Supabase...', 'pending');


### PR DESCRIPTION
## Summary
- move the teacher console Supabase client setup variables above the initialisation logic
- prevent runtime ReferenceErrors by ensuring the Supabase client is declared before initialiseTeacherConsole runs

## Testing
- npm run start


------
https://chatgpt.com/codex/tasks/task_e_68d24fdf1d748327a34486f3e8f98baf