### PR TITLE
Fix eraser handling for single point strokes

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -345,6 +345,19 @@ function checkErase(x, y) {
 
     for (let i = paths.length - 1; i >= 0; i -= 1) {
         const path = paths[i];
+        if (!path || !Array.isArray(path.points) || path.points.length === 0) {
+            continue;
+        }
+
+        if (path.points.length === 1) {
+            const [pointX, pointY] = path.points[0];
+            if (distToSegment(x, y, pointX, pointY, pointX, pointY) <= eraseRadius) {
+                paths.splice(i, 1);
+                erased = true;
+            }
+            continue;
+        }
+
         for (let j = 1; j < path.points.length; j += 1) {
             const [x1, y1] = path.points[j - 1];
             const [x2, y2] = path.points[j];


### PR DESCRIPTION
## Summary
- guard the eraser loop against empty or malformed path data
- allow the eraser to remove single-point (dot) strokes by checking the point distance

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d25c47490c8327b28b8dbd0e704305