### PR TITLE
Add student canvas fullscreen and polish layout

### DIFF
--- a/public/js/theme-toggle.js
+++ b/public/js/theme-toggle.js
@@ -1,0 +1,73 @@
+const THEME_STORAGE_KEY = 'preferred-theme';
+const root = document.documentElement;
+const toggleButton = document.getElementById('themeToggle');
+const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+const isValidTheme = (value) => value === 'light' || value === 'dark';
+
+const readStoredTheme = () => {
+    try {
+        const stored = localStorage.getItem(THEME_STORAGE_KEY);
+        return isValidTheme(stored) ? stored : null;
+    } catch (error) {
+        console.warn('Unable to access localStorage for theme preference.', error);
+        return null;
+    }
+};
+
+const writeStoredTheme = (value) => {
+    try {
+        localStorage.setItem(THEME_STORAGE_KEY, value);
+    } catch (error) {
+        console.warn('Unable to persist theme preference.', error);
+    }
+};
+
+const applyTheme = (theme) => {
+    const nextTheme = isValidTheme(theme) ? theme : 'light';
+    root.setAttribute('data-theme', nextTheme);
+
+    if (toggleButton) {
+        toggleButton.dataset.theme = nextTheme;
+        toggleButton.setAttribute('aria-pressed', nextTheme === 'dark' ? 'true' : 'false');
+        toggleButton.setAttribute(
+            'aria-label',
+            nextTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+        );
+    }
+};
+
+const initialiseTheme = () => {
+    const stored = readStoredTheme();
+    const initialTheme = stored ?? (mediaQuery.matches ? 'dark' : 'light');
+    applyTheme(initialTheme);
+};
+
+initialiseTheme();
+
+if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+        const currentTheme = root.getAttribute('data-theme');
+        const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        applyTheme(nextTheme);
+        writeStoredTheme(nextTheme);
+    });
+}
+
+if (mediaQuery.addEventListener) {
+    mediaQuery.addEventListener('change', (event) => {
+        const stored = readStoredTheme();
+        if (stored) {
+            return;
+        }
+        applyTheme(event.matches ? 'dark' : 'light');
+    });
+} else if (mediaQuery.addListener) {
+    mediaQuery.addListener((event) => {
+        const stored = readStoredTheme();
+        if (stored) {
+            return;
+        }
+        applyTheme(event.matches ? 'dark' : 'light');
+    });
+}

--- a/public/login.html
+++ b/public/login.html
@@ -8,8 +8,25 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <script type="module" src="js/theme-toggle.js" defer></script>
 </head>
 <body class="page page--auth">
+    <button id="themeToggle" class="theme-toggle" type="button" aria-label="Switch to dark mode" aria-pressed="false" data-theme="light">
+        <svg class="theme-toggle__icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle class="theme-toggle__sun-core" cx="12" cy="12" r="4"></circle>
+            <g class="theme-toggle__sun-rays">
+                <line x1="12" y1="2" x2="12" y2="5"></line>
+                <line x1="12" y1="19" x2="12" y2="22"></line>
+                <line x1="4.22" y1="4.22" x2="6.34" y2="6.34"></line>
+                <line x1="17.66" y1="17.66" x2="19.78" y2="19.78"></line>
+                <line x1="2" y1="12" x2="5" y2="12"></line>
+                <line x1="19" y1="12" x2="22" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="6.34" y2="17.66"></line>
+                <line x1="17.66" y1="6.34" x2="19.78" y2="4.22"></line>
+            </g>
+            <path class="theme-toggle__moon" d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+    </button>
     <main class="auth-layout">
         <section class="auth-card">
             <div class="auth-card__header">

--- a/public/student.html
+++ b/public/student.html
@@ -8,10 +8,27 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <script type="module" src="js/theme-toggle.js" defer></script>
     <script src="/config.js"></script>
     <script type="module" src="js/student.js" defer></script>
 </head>
 <body class="page page--student">
+    <button id="themeToggle" class="theme-toggle" type="button" aria-label="Switch to dark mode" aria-pressed="false" data-theme="light">
+        <svg class="theme-toggle__icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle class="theme-toggle__sun-core" cx="12" cy="12" r="4"></circle>
+            <g class="theme-toggle__sun-rays">
+                <line x1="12" y1="2" x2="12" y2="5"></line>
+                <line x1="12" y1="19" x2="12" y2="22"></line>
+                <line x1="4.22" y1="4.22" x2="6.34" y2="6.34"></line>
+                <line x1="17.66" y1="17.66" x2="19.78" y2="19.78"></line>
+                <line x1="2" y1="12" x2="5" y2="12"></line>
+                <line x1="19" y1="12" x2="22" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="6.34" y2="17.66"></line>
+                <line x1="17.66" y1="6.34" x2="19.78" y2="4.22"></line>
+            </g>
+            <path class="theme-toggle__moon" d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+    </button>
     <header class="top-bar top-bar--student">
         <div class="top-bar__titles">
             <p class="eyebrow">Student workspace</p>
@@ -26,8 +43,22 @@
     </header>
 
     <main class="student-layout">
-        <section class="canvas-panel">
-            <canvas id="drawingCanvas"></canvas>
+        <section class="canvas-panel" id="canvasPanel">
+            <div class="canvas-panel__header">
+                <div class="canvas-panel__title">
+                    <span class="canvas-panel__eyebrow">Creative space</span>
+                    <h2>Your live canvas</h2>
+                </div>
+                <button id="fullscreenBtn" class="icon-btn icon-btn--ghost" type="button" aria-pressed="false" aria-label="Enter fullscreen">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path class="icon-enter" d="M4 9V4h5M4 4l6 6M20 9V4h-5M20 4l-6 6M4 15v5h5M4 20l6-6M20 15v5h-5M20 20l-6-6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+                        <path class="icon-exit" d="M9 4H4v5M4 4l6 6M15 4h5v5M20 4l-6 6M9 20H4v-5M4 20l6-6M15 20h5v-5M20 20l-6-6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+                    </svg>
+                </button>
+            </div>
+            <div class="canvas-panel__stage">
+                <canvas id="drawingCanvas"></canvas>
+            </div>
         </section>
 
         <aside class="control-panel">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,18 +1,78 @@
 :root {
     color-scheme: light;
     --bg-gradient: radial-gradient(circle at top left, #eef2ff, #e0f2fe 45%, #f9fafb 100%);
+    --page-overlay: radial-gradient(circle at 10% 20%, rgba(99, 102, 241, 0.12), transparent 45%),
+                    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.1), transparent 40%);
     --surface: #ffffff;
     --surface-muted: rgba(255, 255, 255, 0.65);
+    --surface-soft: rgba(15, 23, 42, 0.04);
+    --surface-strong: rgba(255, 255, 255, 0.9);
     --border: rgba(15, 23, 42, 0.08);
+    --border-strong: rgba(148, 163, 184, 0.3);
     --primary: #6366f1;
     --primary-strong: #4f46e5;
     --primary-soft: rgba(99, 102, 241, 0.12);
     --accent: #0ea5e9;
     --text-strong: #0f172a;
     --text-muted: #475569;
+    --text-inverse: #f8fafc;
     --success: #10b981;
     --danger: #ef4444;
+    --shadow-primary: 0 12px 30px rgba(99, 102, 241, 0.28);
+    --shadow-primary-hover: 0 18px 38px rgba(99, 102, 241, 0.32);
+    --shadow-elevated: 0 10px 24px rgba(15, 23, 42, 0.08);
+    --shadow-card: 0 32px 70px rgba(15, 23, 42, 0.12);
+    --shadow-panel: 0 24px 50px rgba(15, 23, 42, 0.12);
+    --shadow-chip: 0 16px 32px rgba(15, 23, 42, 0.12);
+    --shadow-color-btn: 0 10px 18px rgba(15, 23, 42, 0.1);
+    --shadow-soft: 0 16px 26px rgba(99, 102, 241, 0.25);
+    --shadow-tool-active: 0 16px 28px rgba(99, 102, 241, 0.28);
+    --input-bg: rgba(148, 163, 184, 0.15);
+    --input-bg-focus: rgba(255, 255, 255, 0.9);
+    --range-track: rgba(99, 102, 241, 0.25);
+    --focus-primary: 0 0 0 6px rgba(99, 102, 241, 0.18);
+    --focus-success: 0 0 0 6px rgba(16, 185, 129, 0.16);
+    --focus-danger: 0 0 0 6px rgba(239, 68, 68, 0.16);
+    --focus-muted: 0 0 0 6px rgba(148, 163, 184, 0.25);
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+:root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg-gradient: radial-gradient(circle at top left, #0b1120, #0f172a 55%, #111827 100%);
+    --page-overlay: radial-gradient(circle at 15% 20%, rgba(59, 130, 246, 0.25), transparent 45%),
+                    radial-gradient(circle at 85% 0%, rgba(14, 165, 233, 0.18), transparent 40%);
+    --surface: #111827;
+    --surface-muted: rgba(17, 24, 39, 0.72);
+    --surface-soft: rgba(148, 163, 184, 0.08);
+    --surface-strong: rgba(15, 23, 42, 0.8);
+    --border: rgba(148, 163, 184, 0.25);
+    --border-strong: rgba(148, 163, 184, 0.35);
+    --primary: #8b5cf6;
+    --primary-strong: #c4b5fd;
+    --primary-soft: rgba(139, 92, 246, 0.25);
+    --accent: #38bdf8;
+    --text-strong: #f8fafc;
+    --text-muted: #94a3b8;
+    --text-inverse: #0f172a;
+    --success: #34d399;
+    --danger: #f87171;
+    --shadow-primary: 0 14px 28px rgba(99, 102, 241, 0.45);
+    --shadow-primary-hover: 0 18px 36px rgba(129, 140, 248, 0.55);
+    --shadow-elevated: 0 14px 34px rgba(2, 6, 23, 0.55);
+    --shadow-card: 0 32px 70px rgba(2, 6, 23, 0.65);
+    --shadow-panel: 0 28px 64px rgba(2, 6, 23, 0.68);
+    --shadow-chip: 0 20px 48px rgba(2, 6, 23, 0.6);
+    --shadow-color-btn: 0 14px 24px rgba(2, 6, 23, 0.6);
+    --shadow-soft: 0 18px 32px rgba(129, 140, 248, 0.45);
+    --shadow-tool-active: 0 20px 38px rgba(129, 140, 248, 0.5);
+    --input-bg: rgba(30, 41, 59, 0.7);
+    --input-bg-focus: rgba(30, 41, 59, 0.95);
+    --range-track: rgba(129, 140, 248, 0.35);
+    --focus-primary: 0 0 0 6px rgba(129, 140, 248, 0.35);
+    --focus-success: 0 0 0 6px rgba(52, 211, 153, 0.28);
+    --focus-danger: 0 0 0 6px rgba(248, 113, 113, 0.28);
+    --focus-muted: 0 0 0 6px rgba(148, 163, 184, 0.2);
 }
 
 * {
@@ -27,6 +87,11 @@ body {
     min-height: 100vh;
 }
 
+body.is-canvas-fullscreen {
+    overflow: hidden;
+    background: var(--surface);
+}
+
 .page {
     min-height: 100vh;
     display: flex;
@@ -39,8 +104,7 @@ body {
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: radial-gradient(circle at 10% 20%, rgba(99, 102, 241, 0.12), transparent 45%),
-                radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.1), transparent 40%);
+    background: var(--page-overlay);
 }
 
 main {
@@ -72,13 +136,13 @@ button {
     color: #fff;
     padding: 0.85rem 1.8rem;
     font-weight: 600;
-    box-shadow: 0 12px 30px rgba(99, 102, 241, 0.28);
+    box-shadow: var(--shadow-primary);
 }
 
 .primary-btn:hover {
     background: var(--primary-strong);
     transform: translateY(-2px);
-    box-shadow: 0 18px 38px rgba(99, 102, 241, 0.32);
+    box-shadow: var(--shadow-primary-hover);
 }
 
 .secondary-btn {
@@ -87,27 +151,167 @@ button {
     border: 1px solid var(--border);
     padding: 0.75rem 1.6rem;
     font-weight: 600;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+    box-shadow: var(--shadow-elevated);
 }
 
 .secondary-btn:hover {
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-strong);
     transform: translateY(-2px);
 }
 
 .ghost-btn {
-    background: rgba(15, 23, 42, 0.04);
+    background: var(--surface-soft);
     color: var(--text-strong);
     padding: 0.7rem 1.4rem;
     font-weight: 500;
 }
 
 .ghost-btn:hover {
-    background: rgba(99, 102, 241, 0.12);
+    background: var(--primary-soft);
 }
 
 .ghost-btn--danger {
     color: var(--danger);
+}
+
+.icon-btn {
+    width: 46px;
+    height: 46px;
+    border-radius: 16px;
+    border: 1px solid var(--border);
+    background: var(--surface-soft);
+    color: var(--text-strong);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-elevated);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.icon-btn--ghost {
+    background: var(--surface);
+    border-color: var(--border);
+}
+
+:root[data-theme="dark"] .icon-btn--ghost {
+    background: rgba(15, 23, 42, 0.72);
+}
+
+.icon-btn:hover {
+    background: var(--primary);
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-primary);
+}
+
+.icon-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
+}
+
+.icon-btn svg {
+    width: 22px;
+    height: 22px;
+}
+
+.icon-btn .icon-exit {
+    opacity: 0;
+    transform: scale(0.85);
+    transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.icon-btn .icon-enter {
+    opacity: 1;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.icon-btn.is-active .icon-enter {
+    opacity: 0;
+    transform: scale(0.85);
+}
+
+.icon-btn.is-active .icon-exit {
+    opacity: 1;
+    transform: scale(1);
+}
+
+.icon-btn.is-active {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: var(--shadow-primary);
+}
+
+/* Theme toggle */
+.theme-toggle {
+    position: absolute;
+    top: 1.25rem;
+    right: clamp(1.25rem, 5vw, 3rem);
+    width: 46px;
+    height: 46px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-strong);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-elevated);
+    transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    z-index: 5;
+}
+
+.theme-toggle:hover {
+    background: var(--surface-strong);
+    transform: translateY(-2px);
+}
+
+.theme-toggle:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
+}
+
+.theme-toggle__icon {
+    width: 22px;
+    height: 22px;
+    display: block;
+}
+
+.theme-toggle__sun-core {
+    fill: currentColor;
+    opacity: 1;
+    transform-origin: 50% 50%;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle__sun-rays line {
+    stroke: currentColor;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    opacity: 1;
+    transform-origin: 50% 50%;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle__moon {
+    stroke: currentColor;
+    stroke-width: 1.2;
+    fill: currentColor;
+    stroke-linejoin: round;
+    opacity: 0;
+    transform: scale(0.8);
+    transform-origin: 50% 50%;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle[data-theme="dark"] .theme-toggle__sun-core,
+.theme-toggle[data-theme="dark"] .theme-toggle__sun-rays line {
+    opacity: 0;
+    transform: scale(0.6);
+}
+
+.theme-toggle[data-theme="dark"] .theme-toggle__moon {
+    opacity: 1;
+    transform: scale(1);
 }
 
 button:disabled {
@@ -138,7 +342,7 @@ button:disabled {
     background: var(--surface);
     border-radius: 22px;
     padding: 2.5rem;
-    box-shadow: 0 32px 70px rgba(15, 23, 42, 0.12);
+    box-shadow: var(--shadow-card);
     backdrop-filter: blur(8px);
 }
 
@@ -178,7 +382,7 @@ input[type="password"] {
     width: 100%;
     border-radius: 14px;
     border: 1px solid transparent;
-    background: rgba(148, 163, 184, 0.15);
+    background: var(--input-bg);
     padding: 0.85rem 1rem;
     font-size: 1rem;
     color: var(--text-strong);
@@ -192,14 +396,15 @@ input[type="number"]:focus,
 input[type="email"]:focus,
 input[type="password"]:focus {
     border-color: var(--primary);
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--input-bg-focus);
+    box-shadow: var(--focus-primary);
 }
 
 input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
     height: 6px;
-    background: rgba(99, 102, 241, 0.25);
+    background: var(--range-track);
     border-radius: 999px;
 }
 
@@ -210,7 +415,7 @@ input[type="range"]::-webkit-slider-thumb {
     height: 18px;
     border-radius: 50%;
     background: var(--primary);
-    box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.18);
+    box-shadow: var(--focus-primary);
     border: none;
 }
 
@@ -220,7 +425,7 @@ input[type="range"]::-moz-range-thumb {
     border-radius: 50%;
     background: var(--primary);
     border: none;
-    box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.18);
+    box-shadow: var(--focus-primary);
 }
 
 .auth-meta {
@@ -243,7 +448,7 @@ input[type="range"]::-moz-range-thumb {
     background: var(--surface-muted);
     border-radius: 22px;
     padding: 1.8rem;
-    border: 1px solid rgba(148, 163, 184, 0.25);
+    border: 1px solid var(--border-strong);
     backdrop-filter: blur(6px);
 }
 
@@ -280,7 +485,7 @@ input[type="range"]::-moz-range-thumb {
     font-size: 0.85rem;
     text-transform: uppercase;
     letter-spacing: 0.28em;
-    color: rgba(15, 23, 42, 0.5);
+    color: var(--text-muted);
     font-weight: 700;
 }
 
@@ -293,10 +498,10 @@ input[type="range"]::-moz-range-thumb {
     padding: 0.55rem 1.4rem;
     border-radius: 999px;
     font-weight: 600;
-    background: rgba(15, 23, 42, 0.06);
+    background: var(--surface-soft);
     color: var(--text-strong);
-    border: 1px solid transparent;
-    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-elevated);
 }
 
 .status-badge--success {
@@ -317,6 +522,26 @@ input[type="range"]::-moz-range-thumb {
     border-color: rgba(239, 68, 68, 0.35);
 }
 
+:root[data-theme="dark"] .status-badge {
+    background: rgba(148, 163, 184, 0.12);
+    border-color: rgba(148, 163, 184, 0.3);
+}
+
+:root[data-theme="dark"] .status-badge--success {
+    background: rgba(52, 211, 153, 0.18);
+    border-color: rgba(52, 211, 153, 0.35);
+}
+
+:root[data-theme="dark"] .status-badge--pending {
+    background: rgba(56, 189, 248, 0.2);
+    border-color: rgba(56, 189, 248, 0.35);
+}
+
+:root[data-theme="dark"] .status-badge--error {
+    background: rgba(248, 113, 113, 0.2);
+    border-color: rgba(248, 113, 113, 0.32);
+}
+
 /* Teacher layout */
 .page--teacher main {
     padding: 0 clamp(1.5rem, 5vw, 3.5rem) 4rem;
@@ -327,6 +552,12 @@ input[type="range"]::-moz-range-thumb {
     gap: 2.5rem;
 }
 
+.session-panel {
+    display: grid;
+    gap: clamp(2rem, 3vw, 2.75rem);
+    align-content: start;
+}
+
 .session-card {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -335,7 +566,84 @@ input[type="range"]::-moz-range-thumb {
     background: var(--surface);
     padding: clamp(1.8rem, 3vw, 2.5rem);
     border-radius: 24px;
-    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
+    box-shadow: var(--shadow-card);
+}
+
+.session-card--tools {
+    align-items: flex-start;
+    gap: 1.8rem;
+}
+
+.session-tools__header {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.session-tools__upload {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.session-tools__upload-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
+.session-tools__upload button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.session-tools__filename {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.session-tools__preview {
+    width: min(100%, 320px);
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: var(--surface-soft);
+    box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.session-tools__preview img {
+    width: 100%;
+    display: block;
+}
+
+.session-tools__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.session-tools__status {
+    font-size: 0.92rem;
+    color: var(--text-muted);
+}
+
+.session-tools__divider {
+    width: 100%;
+    height: 1px;
+    background: var(--border);
+    margin: 0.25rem 0 0.75rem;
+}
+
+.session-tools__flow {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.session-tools__next {
+    justify-self: flex-start;
 }
 
 .session-card__details {
@@ -358,11 +666,11 @@ input[type="range"]::-moz-range-thumb {
     width: 220px;
     height: 220px;
     margin: 0 auto;
-    background: rgba(255, 255, 255, 0.9);
+    background: var(--surface-strong);
     border-radius: 18px;
     display: grid;
     place-items: center;
-    box-shadow: inset 0 0 0 1px var(--border), 0 20px 40px rgba(15, 23, 42, 0.12);
+    box-shadow: inset 0 0 0 1px var(--border), var(--shadow-panel);
 }
 
 .copy-url {
@@ -406,7 +714,7 @@ input[type="range"]::-moz-range-thumb {
     background: var(--surface);
     border-radius: 22px;
     padding: 1.5rem;
-    box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+    box-shadow: var(--shadow-panel);
     display: grid;
     gap: 1rem;
 }
@@ -426,13 +734,13 @@ input[type="range"]::-moz-range-thumb {
     height: 12px;
     border-radius: 50%;
     background: var(--success);
-    box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.16);
+    box-shadow: var(--focus-success);
     transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .student-card__status-dot--error {
     background: var(--danger);
-    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.16);
+    box-shadow: var(--focus-danger);
 }
 
 .student-card__meta {
@@ -441,12 +749,12 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .student-card__canvas {
-    background: rgba(148, 163, 184, 0.12);
+    background: var(--surface-soft);
     border-radius: 18px;
     padding: 0.75rem;
     display: grid;
     place-items: center;
-    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+    box-shadow: inset 0 0 0 1px var(--border);
 }
 
 .student-card__canvas canvas {
@@ -471,16 +779,139 @@ input[type="range"]::-moz-range-thumb {
 .canvas-panel {
     background: var(--surface);
     border-radius: 24px;
-    padding: clamp(1.5rem, 3vw, 2rem);
-    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
+    padding: clamp(1.6rem, 3vw, 2.4rem);
+    box-shadow: var(--shadow-card);
     display: grid;
+    gap: clamp(1.2rem, 2vw, 1.8rem);
+    grid-template-rows: auto minmax(0, 1fr);
+    position: relative;
+    overflow: hidden;
 }
 
-.canvas-panel canvas {
+.canvas-panel::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 0%, rgba(99, 102, 241, 0.12), transparent 55%),
+                radial-gradient(circle at 90% 10%, rgba(14, 165, 233, 0.1), transparent 45%);
+    opacity: 0.6;
+    pointer-events: none;
+    mix-blend-mode: color-dodge;
+}
+
+.canvas-panel__header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.canvas-panel__title {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.canvas-panel__eyebrow {
+    font-size: 0.75rem;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: var(--primary-strong);
+    font-weight: 700;
+}
+
+.canvas-panel__stage {
+    position: relative;
+    z-index: 1;
+    border-radius: 20px;
+    padding: clamp(0.85rem, 3vw, 1.6rem);
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.14), rgba(14, 165, 233, 0.16));
+    box-shadow: inset 0 0 0 1px var(--border-strong);
+    display: grid;
+    place-items: center;
+    min-height: 0;
+}
+
+.canvas-panel__stage::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), transparent 55%);
+    pointer-events: none;
+}
+
+.canvas-panel__stage canvas {
     width: 100%;
-    border-radius: 18px;
-    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+    max-width: 100%;
+    border-radius: 16px;
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.18), inset 0 0 0 1px rgba(255, 255, 255, 0.6);
     background: #fff;
+    aspect-ratio: 4 / 3;
+}
+
+.canvas-panel--fullscreen {
+    border-radius: 0;
+    box-shadow: none;
+    padding: clamp(1.2rem, 4vw, 2.8rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.4rem, 3vw, 2rem);
+}
+
+.canvas-panel--fullscreen .canvas-panel__stage {
+    flex: 1;
+    width: 100%;
+    padding: clamp(1rem, 4vw, 2.2rem);
+    background: linear-gradient(140deg, rgba(99, 102, 241, 0.22), rgba(14, 165, 233, 0.22));
+}
+
+.canvas-panel--fullscreen .canvas-panel__stage canvas {
+    height: 100%;
+    width: 100%;
+    max-height: none;
+}
+
+.canvas-panel:fullscreen,
+.canvas-panel:-webkit-full-screen {
+    border-radius: 0;
+    box-shadow: none;
+}
+
+.canvas-panel:fullscreen .canvas-panel__stage,
+.canvas-panel:-webkit-full-screen .canvas-panel__stage {
+    flex: 1;
+    width: 100%;
+}
+
+.canvas-panel:fullscreen .canvas-panel__stage canvas,
+.canvas-panel:-webkit-full-screen .canvas-panel__stage canvas {
+    height: 100%;
+    width: 100%;
+}
+
+:root[data-theme="dark"] .canvas-panel::after {
+    background: radial-gradient(circle at 15% 0%, rgba(139, 92, 246, 0.18), transparent 55%),
+                radial-gradient(circle at 85% 15%, rgba(56, 189, 248, 0.12), transparent 45%);
+}
+
+:root[data-theme="dark"] .canvas-panel__eyebrow {
+    color: var(--primary-strong);
+}
+
+:root[data-theme="dark"] .canvas-panel__stage {
+    background: linear-gradient(135deg, rgba(139, 92, 246, 0.28), rgba(56, 189, 248, 0.22));
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.32);
+}
+
+:root[data-theme="dark"] .canvas-panel__stage::after {
+    background: radial-gradient(circle at 30% 30%, rgba(148, 163, 184, 0.32), transparent 55%);
+}
+
+:root[data-theme="dark"] .canvas-panel__stage canvas {
+    background: rgba(15, 23, 42, 0.85);
+    box-shadow: 0 28px 60px rgba(2, 6, 23, 0.6), inset 0 0 0 1px rgba(148, 163, 184, 0.28);
 }
 
 .control-panel {
@@ -495,7 +926,7 @@ input[type="range"]::-moz-range-thumb {
     background: var(--surface);
     border-radius: 22px;
     padding: 1.6rem;
-    box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+    box-shadow: var(--shadow-panel);
     display: grid;
     gap: 1rem;
 }
@@ -510,7 +941,7 @@ input[type="range"]::-moz-range-thumb {
     height: 42px;
     border-radius: 50%;
     border: 3px solid transparent;
-    box-shadow: 0 10px 18px rgba(15, 23, 42, 0.1);
+    box-shadow: var(--shadow-color-btn);
     cursor: pointer;
     transition: transform 0.18s ease, border 0.18s ease, box-shadow 0.18s ease;
 }
@@ -523,7 +954,7 @@ input[type="range"]::-moz-range-thumb {
 .color-btn.active {
     transform: translateY(-2px) scale(1.05);
     border-color: var(--primary);
-    box-shadow: 0 16px 26px rgba(99, 102, 241, 0.25);
+    box-shadow: var(--shadow-soft);
 }
 
 .mode-buttons {
@@ -533,7 +964,7 @@ input[type="range"]::-moz-range-thumb {
 
 .tool-btn {
     flex: 1;
-    background: rgba(99, 102, 241, 0.12);
+    background: var(--primary-soft);
     color: var(--primary-strong);
     padding: 0.75rem 1rem;
     font-weight: 600;
@@ -542,7 +973,7 @@ input[type="range"]::-moz-range-thumb {
 .tool-btn.active {
     background: var(--primary);
     color: #fff;
-    box-shadow: 0 16px 28px rgba(99, 102, 241, 0.28);
+    box-shadow: var(--shadow-tool-active);
 }
 
 .action-buttons {
@@ -566,15 +997,15 @@ input[type="range"]::-moz-range-thumb {
     grid-template-columns: auto auto;
     column-gap: 0.5rem;
     align-items: baseline;
-    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
-    border: 1px solid rgba(148, 163, 184, 0.3);
+    box-shadow: var(--shadow-chip);
+    border: 1px solid var(--border-strong);
 }
 
 .chip-label {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.22em;
-    color: rgba(15, 23, 42, 0.5);
+    color: var(--text-muted);
     font-weight: 700;
 }
 
@@ -597,6 +1028,13 @@ input[type="range"]::-moz-range-thumb {
 }
 
 @media (max-width: 720px) {
+    .theme-toggle {
+        top: 1rem;
+        right: clamp(1rem, 6vw, 2.2rem);
+        width: 42px;
+        height: 42px;
+    }
+
     .top-bar {
         flex-direction: column;
         align-items: flex-start;
@@ -620,6 +1058,11 @@ input[type="range"]::-moz-range-thumb {
 }
 
 @media (max-width: 540px) {
+    .theme-toggle {
+        width: 38px;
+        height: 38px;
+    }
+
     .copy-url {
         flex-direction: column;
         align-items: stretch;

--- a/public/teacher.html
+++ b/public/teacher.html
@@ -8,11 +8,28 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
+    <script type="module" src="js/theme-toggle.js" defer></script>
     <script src="/config.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js" defer></script>
     <script type="module" src="js/teacher.js" defer></script>
 </head>
 <body class="page page--teacher">
+    <button id="themeToggle" class="theme-toggle" type="button" aria-label="Switch to dark mode" aria-pressed="false" data-theme="light">
+        <svg class="theme-toggle__icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle class="theme-toggle__sun-core" cx="12" cy="12" r="4"></circle>
+            <g class="theme-toggle__sun-rays">
+                <line x1="12" y1="2" x2="12" y2="5"></line>
+                <line x1="12" y1="19" x2="12" y2="22"></line>
+                <line x1="4.22" y1="4.22" x2="6.34" y2="6.34"></line>
+                <line x1="17.66" y1="17.66" x2="19.78" y2="19.78"></line>
+                <line x1="2" y1="12" x2="5" y2="12"></line>
+                <line x1="19" y1="12" x2="22" y2="12"></line>
+                <line x1="4.22" y1="19.78" x2="6.34" y2="17.66"></line>
+                <line x1="17.66" y1="6.34" x2="19.78" y2="4.22"></line>
+            </g>
+            <path class="theme-toggle__moon" d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+    </button>
     <header class="top-bar">
         <div class="top-bar__titles">
             <p class="eyebrow">Teacher console</p>
@@ -37,6 +54,36 @@
                         <button id="copyBtn" class="secondary-btn" type="button">Copy link</button>
                     </div>
                     <p class="status-text" id="connection-status">Connecting to Supabase...</p>
+                </div>
+            </div>
+
+            <div class="session-card session-card--tools">
+                <div class="session-tools__header">
+                    <h2>Classroom controls</h2>
+                    <p class="panel-subtitle">Share a reference image with your class and reset canvases when it's time for the next prompt.</p>
+                </div>
+
+                <div class="session-tools__upload">
+                    <label for="referenceImage" class="secondary-btn session-tools__upload-btn">Choose image</label>
+                    <input type="file" id="referenceImage" accept="image/*" hidden>
+                    <button id="clearImageBtn" class="ghost-btn" type="button" hidden>Clear selection</button>
+                </div>
+                <p class="session-tools__filename" id="referenceFileName">No image selected</p>
+
+                <div class="session-tools__preview" id="referencePreview" hidden>
+                    <img id="referencePreviewImage" alt="Selected reference preview">
+                </div>
+
+                <div class="session-tools__actions">
+                    <button id="pushImageBtn" class="primary-btn" type="button" disabled>Push to students</button>
+                </div>
+                <p class="session-tools__status" id="referenceStatus">Choose an image to send to your class.</p>
+
+                <div class="session-tools__divider"></div>
+                <div class="session-tools__flow">
+                    <h3>Ready for the next question?</h3>
+                    <p class="panel-subtitle">Clear every student's canvas and remove any shared background image.</p>
+                    <button id="nextQuestionBtn" class="ghost-btn ghost-btn--danger session-tools__next" type="button">Next question</button>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- add a reusable theme toggle button to the login, student, and teacher pages and persist the user's preference
- expand the shared stylesheet with light and dark design tokens plus component tweaks to keep contrast in both modes
- introduce a polished student canvas panel with a fullscreen toggle and responsive styling for a more immersive drawing experience
- space the teacher session cards and refine the visual treatment so classroom controls breathe

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d25f73788c8327a46c44eedba046fa