### PR TITLE
Add stylus mode toggle with palm rejection support

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -112,6 +112,15 @@
             </div>
 
             <div class="control-group">
+                <h2>Input</h2>
+                <button id="stylusModeToggle" class="toggle-btn" type="button" aria-pressed="false">
+                    <span class="toggle-btn__label">Stylus mode</span>
+                    <span id="stylusModeStatus" class="toggle-btn__status">Off</span>
+                </button>
+                <p class="control-hint">Ignore accidental finger touches while drawing with a stylus.</p>
+            </div>
+
+            <div class="control-group">
                 <h2>Actions</h2>
                 <div class="action-buttons">
                     <button id="undoBtn" class="ghost-btn" type="button">Undo</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -830,6 +830,7 @@ input[type="range"]::-moz-range-thumb {
     border-radius: 18px;
     box-shadow: inset 0 0 0 1px var(--border-strong);
     background: #fff;
+    touch-action: none;
 }
 
 .canvas-panel:fullscreen,
@@ -1007,6 +1008,52 @@ input[type="range"]::-moz-range-thumb {
     background: var(--primary);
     color: #fff;
     box-shadow: var(--shadow-tool-active);
+}
+
+.toggle-btn {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    background: var(--primary-soft);
+    color: var(--primary-strong);
+    padding: 0.85rem 1rem;
+    border-radius: 16px;
+    border: none;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggle-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
+}
+
+.toggle-btn[aria-pressed="true"] {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: var(--shadow-tool-active);
+}
+
+.toggle-btn__label {
+    font-size: 1rem;
+}
+
+.toggle-btn__status {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.toggle-btn[aria-pressed="true"] .toggle-btn__status {
+    color: inherit;
+}
+
+.control-hint {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin: 0;
 }
 
 .action-buttons {


### PR DESCRIPTION
## Summary
- add a stylus mode toggle to the student workspace so users can opt into palm rejection
- style the new control and prevent default touch gestures on the canvas surface
- switch drawing handlers to pointer events when available and ignore non-pen touches while stylus mode is active

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d61e2b379483278d2d1e83b1d819e9