### PR TITLE
Anchor student canvas quick actions

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -338,6 +338,8 @@ function updateFullscreenUI() {
     }
 
     fullscreenToggle.setAttribute('aria-pressed', String(isFullscreen));
+    fullscreenToggle.setAttribute('aria-label', isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen');
+    fullscreenToggle.title = isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen';
 
     if (fullscreenToggleLabel) {
         fullscreenToggleLabel.textContent = isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen';

--- a/public/student.html
+++ b/public/student.html
@@ -49,32 +49,47 @@
                     <h2 class="canvas-panel__title">Creative canvas</h2>
                     <p class="canvas-panel__subtitle">Go full screen for focus mode and extra drawing space.</p>
                 </div>
-                <button id="fullscreenToggle" class="canvas-panel__action-btn" type="button" aria-pressed="false">
-                    <svg id="fullscreenEnterIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <polyline points="5 9 5 5 9 5"></polyline>
-                        <line x1="5" y1="5" x2="10" y2="10"></line>
-                        <polyline points="19 15 19 19 15 19"></polyline>
-                        <line x1="19" y1="19" x2="14" y2="14"></line>
-                        <polyline points="15 5 19 5 19 9"></polyline>
-                        <line x1="19" y1="5" x2="14" y2="10"></line>
-                        <polyline points="9 19 5 19 5 15"></polyline>
-                        <line x1="5" y1="19" x2="10" y2="14"></line>
-                    </svg>
-                    <svg id="fullscreenExitIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden>
-                        <polyline points="9 9 5 9 5 5"></polyline>
-                        <line x1="5" y1="5" x2="10" y2="10"></line>
-                        <polyline points="15 15 19 15 19 19"></polyline>
-                        <line x1="19" y1="19" x2="14" y2="14"></line>
-                        <polyline points="15 9 19 9 19 5"></polyline>
-                        <line x1="19" y1="5" x2="14" y2="10"></line>
-                        <polyline points="9 15 5 15 5 19"></polyline>
-                        <line x1="5" y1="19" x2="10" y2="14"></line>
-                    </svg>
-                    <span id="fullscreenToggleLabel" class="canvas-panel__action-label">Enter fullscreen</span>
-                </button>
+                <div class="canvas-panel__toolbar-actions">
+                    <button id="fullscreenToggle" class="canvas-panel__action-btn" type="button" aria-pressed="false" aria-label="Enter fullscreen" title="Enter fullscreen">
+                        <svg id="fullscreenEnterIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="5 9 5 5 9 5"></polyline>
+                            <polyline points="19 15 19 19 15 19"></polyline>
+                            <polyline points="15 5 19 5 19 9"></polyline>
+                            <polyline points="9 19 5 19 5 15"></polyline>
+                        </svg>
+                        <svg id="fullscreenExitIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden>
+                            <polyline points="9 5 5 5 5 9"></polyline>
+                            <polyline points="15 19 19 19 19 15"></polyline>
+                            <polyline points="19 9 19 5 15 5"></polyline>
+                            <polyline points="5 15 5 19 9 19"></polyline>
+                        </svg>
+                        <span id="fullscreenToggleLabel" class="visually-hidden">Enter fullscreen</span>
+                    </button>
+                </div>
             </div>
             <div class="canvas-wrapper" id="canvasWrapper">
                 <canvas id="drawingCanvas"></canvas>
+                <div class="canvas-panel__quick-actions" role="group" aria-label="Canvas actions">
+                    <button id="undoBtn" class="quick-action-btn" type="button" aria-label="Undo" title="Undo">
+                        <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="9 15 3 9 9 3"></polyline>
+                            <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
+                        </svg>
+                    </button>
+                    <button id="redoBtn" class="quick-action-btn" type="button" aria-label="Redo" title="Redo">
+                        <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <polyline points="15 3 21 9 15 15"></polyline>
+                            <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
+                        </svg>
+                    </button>
+                    <button id="clearBtn" class="quick-action-btn quick-action-btn--danger" type="button" aria-label="Clear canvas" title="Clear canvas">
+                        <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3 6h18"></path>
+                            <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6"></path>
+                            <path d="M10 6l1-3h2l1 3"></path>
+                        </svg>
+                    </button>
+                </div>
             </div>
             <div class="canvas-panel__color-rail" role="group" aria-label="Quick color markers">
                 <button class="color-btn black active" data-color="#1e1b4b" aria-label="Black"></button>
@@ -106,8 +121,20 @@
             <div class="control-group">
                 <h2>Mode</h2>
                 <div class="mode-buttons">
-                    <button id="drawBtn" class="tool-btn active" type="button">Draw</button>
-                    <button id="eraseBtn" class="tool-btn" type="button">Erase</button>
+                    <button id="drawBtn" class="tool-btn active" type="button">
+                        <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
+                            <path d="M14.75 6.04l3.21 3.21"></path>
+                        </svg>
+                        <span class="tool-btn__label">Brush</span>
+                    </button>
+                    <button id="eraseBtn" class="tool-btn" type="button">
+                        <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
+                            <path d="M6 19.5h7"></path>
+                        </svg>
+                        <span class="tool-btn__label">Eraser</span>
+                    </button>
                 </div>
             </div>
 
@@ -118,15 +145,6 @@
                     <span id="stylusModeStatus" class="toggle-btn__status">Off</span>
                 </button>
                 <p class="control-hint">Ignore accidental finger touches while drawing with a stylus.</p>
-            </div>
-
-            <div class="control-group">
-                <h2>Actions</h2>
-                <div class="action-buttons">
-                    <button id="undoBtn" class="ghost-btn" type="button">Undo</button>
-                    <button id="redoBtn" class="ghost-btn" type="button">Redo</button>
-                    <button id="clearBtn" class="ghost-btn ghost-btn--danger" type="button">Clear</button>
-                </div>
             </div>
 
             <div class="control-note">

--- a/public/styles.css
+++ b/public/styles.css
@@ -116,6 +116,18 @@ p {
     line-height: 1.6;
 }
 
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Buttons */
 button {
     font-family: inherit;
@@ -745,6 +757,82 @@ input[type="range"]::-moz-range-thumb {
     flex-wrap: wrap;
 }
 
+.canvas-panel__toolbar-actions {
+    display: grid;
+    gap: 0.75rem;
+    justify-items: end;
+    align-items: center;
+}
+
+.canvas-panel__quick-actions {
+    position: absolute;
+    right: clamp(0.9rem, 2.5vw, 1.5rem);
+    bottom: clamp(0.9rem, 2.5vw, 1.5rem);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-strong);
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: var(--shadow-panel);
+    backdrop-filter: blur(12px);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+    z-index: 2;
+}
+
+.canvas-panel__quick-actions:hover {
+    box-shadow: var(--shadow-soft);
+    transform: translateY(-1px);
+}
+
+.quick-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    padding: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-strong);
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.quick-action-btn:hover {
+    background: var(--primary-soft);
+    color: var(--primary-strong);
+    transform: translateY(-1px);
+}
+
+.quick-action-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
+    background: var(--primary-soft);
+    color: var(--primary-strong);
+}
+
+.quick-action-btn--danger {
+    color: var(--danger);
+}
+
+.quick-action-btn--danger:hover {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.12);
+}
+
+.quick-action-btn__icon {
+    width: 20px;
+    height: 20px;
+}
+
+:root[data-theme="dark"] .canvas-panel__quick-actions {
+    background: rgba(15, 23, 42, 0.82);
+    border-color: rgba(148, 163, 184, 0.45);
+}
+
 .canvas-panel__titles {
     display: grid;
     gap: 0.4rem;
@@ -761,16 +849,16 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .canvas-panel__action-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    padding: 0.7rem 1.1rem;
+    position: relative;
+    display: inline-grid;
+    place-items: center;
+    width: 48px;
+    height: 48px;
+    padding: 0;
     border-radius: 999px;
     background: var(--primary);
     color: var(--text-inverse);
     box-shadow: var(--shadow-primary);
-    font-weight: 600;
     transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
@@ -794,10 +882,6 @@ input[type="range"]::-moz-range-thumb {
     height: 22px;
 }
 
-.canvas-panel__action-label {
-    font-size: 0.95rem;
-}
-
 .canvas-wrapper {
     background: rgba(99, 102, 241, 0.08);
     border-radius: 20px;
@@ -808,6 +892,7 @@ input[type="range"]::-moz-range-thumb {
     width: 100%;
     min-height: clamp(320px, 55vh, 520px);
     transition: background 0.3s ease, box-shadow 0.3s ease;
+    position: relative;
 }
 
 .canvas-wrapper:hover {
@@ -902,8 +987,25 @@ input[type="range"]::-moz-range-thumb {
     z-index: 3;
 }
 
+.canvas-panel:fullscreen .canvas-panel__toolbar-actions,
+.canvas-panel--fullscreen .canvas-panel__toolbar-actions {
+    pointer-events: auto;
+}
+
+.canvas-panel:fullscreen .canvas-panel__quick-actions,
+.canvas-panel--fullscreen .canvas-panel__quick-actions {
+    right: clamp(1.2rem, 3vw, 2.25rem);
+    bottom: clamp(1.2rem, 3vw, 2.25rem);
+    padding: 0.45rem 0.55rem;
+}
+
 .canvas-panel:fullscreen .canvas-panel__action-btn,
 .canvas-panel--fullscreen .canvas-panel__action-btn {
+    pointer-events: auto;
+}
+
+.canvas-panel:fullscreen .quick-action-btn,
+.canvas-panel--fullscreen .quick-action-btn {
     pointer-events: auto;
 }
 
@@ -945,6 +1047,17 @@ input[type="range"]::-moz-range-thumb {
     .canvas-panel__action-btn {
         width: 100%;
         justify-content: center;
+    }
+
+    .canvas-panel__toolbar-actions {
+        width: 100%;
+        justify-items: stretch;
+    }
+
+    .canvas-panel__quick-actions {
+        left: 50%;
+        right: auto;
+        transform: translate(-50%, 0);
     }
 }
 
@@ -998,16 +1111,41 @@ input[type="range"]::-moz-range-thumb {
 
 .tool-btn {
     flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1rem;
+    border-radius: 16px;
     background: var(--primary-soft);
     color: var(--primary-strong);
-    padding: 0.75rem 1rem;
     font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.tool-btn:hover {
+    transform: translateY(-1px);
+    background: rgba(99, 102, 241, 0.2);
+}
+
+.tool-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
 }
 
 .tool-btn.active {
     background: var(--primary);
     color: #fff;
     box-shadow: var(--shadow-tool-active);
+}
+
+.tool-btn__icon {
+    width: 22px;
+    height: 22px;
+}
+
+.tool-btn__label {
+    white-space: nowrap;
 }
 
 .toggle-btn {
@@ -1054,12 +1192,6 @@ input[type="range"]::-moz-range-thumb {
     font-size: 0.85rem;
     color: var(--text-muted);
     margin: 0;
-}
-
-.action-buttons {
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
 }
 
 .control-note {
@@ -1156,12 +1288,23 @@ input[type="range"]::-moz-range-thumb {
         flex-wrap: wrap;
     }
 
-    .action-buttons {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
     .mode-buttons {
         flex-direction: column;
+    }
+
+    .canvas-panel__quick-actions {
+        left: clamp(0.7rem, 6vw, 1.25rem);
+        right: clamp(0.7rem, 6vw, 1.25rem);
+        bottom: clamp(0.7rem, 6vw, 1.25rem);
+        transform: none;
+        padding: 0.35rem 0.4rem;
+        gap: 0.35rem;
+        justify-content: space-between;
+    }
+
+    .quick-action-btn {
+        width: 100%;
+        height: 40px;
+        flex: 1;
     }
 }


### PR DESCRIPTION
## Summary
- move the undo/redo/clear quick actions into a floating control dock anchored on the drawing canvas
- refresh the floating quick-action styling with translucent surfaces, hover effects, and dark-theme tuning
- adjust responsive breakpoints and fullscreen offsets so the dock stays reachable on tablets and phones

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d626bddba483279b488939d305dd14