### PR TITLE
Rework fullscreen canvas controls and stylus handling

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Live Drawing Tool - Student Workspace</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -68,31 +68,105 @@
                 </div>
             </div>
             <div class="canvas-wrapper" id="canvasWrapper">
+                <div class="canvas-topbar" id="canvasTopbar" aria-hidden="true">
+                    <div class="canvas-topbar__section canvas-topbar__section--history" role="group" aria-label="Canvas history">
+                        <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
+                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <polyline points="9 15 3 9 9 3"></polyline>
+                                <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
+                            </svg>
+                        </button>
+                        <button class="quick-action-btn" type="button" data-action="redo" aria-label="Redo" title="Redo">
+                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <polyline points="15 3 21 9 15 15"></polyline>
+                                <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="canvas-topbar__section canvas-topbar__section--colors" role="group" aria-label="Top bar colors">
+                        <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
+                        <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
+                        <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
+                        <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
+                    </div>
+                    <div class="canvas-topbar__section canvas-topbar__section--tools" role="group" aria-label="Drawing mode">
+                        <button class="tool-btn" type="button" data-tool="draw" aria-pressed="false">
+                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
+                                <path d="M14.75 6.04l3.21 3.21"></path>
+                            </svg>
+                            <span class="tool-btn__label">Brush</span>
+                        </button>
+                        <button class="tool-btn" type="button" data-tool="erase" aria-pressed="false">
+                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
+                                <path d="M6 19.5h7"></path>
+                            </svg>
+                            <span class="tool-btn__label">Eraser</span>
+                        </button>
+                    </div>
+                    <div class="canvas-topbar__section canvas-topbar__section--brush">
+                        <label class="slider-field slider-field--topbar">
+                            <span class="chip-label">Brush size</span>
+                            <input type="range" data-brush-size min="1" max="20" value="5">
+                        </label>
+                    </div>
+                    <div class="canvas-topbar__section canvas-topbar__section--stylus">
+                        <button class="toggle-btn toggle-btn--compact" type="button" data-stylus-toggle aria-pressed="true">
+                            <span class="toggle-btn__label">Stylus mode</span>
+                            <span class="toggle-btn__status" data-stylus-status>On</span>
+                        </button>
+                    </div>
+                </div>
                 <canvas id="drawingCanvas"></canvas>
-                <div class="canvas-panel__quick-actions" role="group" aria-label="Canvas actions">
-                    <button id="undoBtn" class="quick-action-btn" type="button" aria-label="Undo" title="Undo">
-                        <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <polyline points="9 15 3 9 9 3"></polyline>
-                            <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
-                        </svg>
-                    </button>
-                    <button id="redoBtn" class="quick-action-btn" type="button" aria-label="Redo" title="Redo">
-                        <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <polyline points="15 3 21 9 15 15"></polyline>
-                            <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
-                        </svg>
-                    </button>
-                    <button id="clearBtn" class="quick-action-btn quick-action-btn--danger" type="button" aria-label="Clear canvas" title="Clear canvas">
-                        <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <path d="M3 6h18"></path>
-                            <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6"></path>
-                            <path d="M10 6l1-3h2l1 3"></path>
-                        </svg>
-                    </button>
+                <div class="canvas-panel__quick-actions" aria-label="Canvas actions">
+                    <div class="quick-actions__cluster" role="group" aria-label="History">
+                        <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
+                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <polyline points="9 15 3 9 9 3"></polyline>
+                                <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
+                            </svg>
+                        </button>
+                        <button class="quick-action-btn" type="button" data-action="redo" aria-label="Redo" title="Redo">
+                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <polyline points="15 3 21 9 15 15"></polyline>
+                                <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
+                            </svg>
+                        </button>
+                        <button class="quick-action-btn quick-action-btn--danger" type="button" data-action="clear" aria-label="Clear canvas" title="Clear canvas">
+                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M3 6h18"></path>
+                                <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6"></path>
+                                <path d="M10 6l1-3h2l1 3"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="quick-actions__cluster" role="group" aria-label="Drawing mode">
+                        <button class="tool-btn" type="button" data-tool="draw" aria-pressed="false">
+                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
+                                <path d="M14.75 6.04l3.21 3.21"></path>
+                            </svg>
+                            <span class="tool-btn__label">Brush</span>
+                        </button>
+                        <button class="tool-btn" type="button" data-tool="erase" aria-pressed="false">
+                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
+                                <path d="M6 19.5h7"></path>
+                            </svg>
+                            <span class="tool-btn__label">Eraser</span>
+                        </button>
+                    </div>
+                    <div class="quick-actions__cluster quick-actions__cluster--stylus" role="group" aria-label="Stylus mode">
+                        <button class="toggle-btn toggle-btn--compact" type="button" data-stylus-toggle aria-pressed="true">
+                            <span class="toggle-btn__label">Stylus</span>
+                            <span class="toggle-btn__status" data-stylus-status>On</span>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div class="canvas-panel__color-rail" role="group" aria-label="Quick color markers">
-                <button class="color-btn black active" data-color="#1e1b4b" aria-label="Black"></button>
+                <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
                 <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
                 <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
                 <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
@@ -103,7 +177,7 @@
             <div class="control-group">
                 <h2>Colors</h2>
                 <div class="color-buttons">
-                    <button class="color-btn black active" data-color="#1e1b4b" aria-label="Black"></button>
+                    <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
                     <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
                     <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
                     <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
@@ -114,35 +188,15 @@
                 <h2>Brush size</h2>
                 <label class="slider-field">
                     <span class="chip-label">Adjust width</span>
-                    <input type="range" id="brushSize" min="1" max="20" value="5">
+                    <input type="range" data-brush-size min="1" max="20" value="5">
                 </label>
             </div>
 
             <div class="control-group">
-                <h2>Mode</h2>
-                <div class="mode-buttons">
-                    <button id="drawBtn" class="tool-btn active" type="button">
-                        <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
-                            <path d="M14.75 6.04l3.21 3.21"></path>
-                        </svg>
-                        <span class="tool-btn__label">Brush</span>
-                    </button>
-                    <button id="eraseBtn" class="tool-btn" type="button">
-                        <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
-                            <path d="M6 19.5h7"></path>
-                        </svg>
-                        <span class="tool-btn__label">Eraser</span>
-                    </button>
-                </div>
-            </div>
-
-            <div class="control-group">
                 <h2>Input</h2>
-                <button id="stylusModeToggle" class="toggle-btn" type="button" aria-pressed="false">
+                <button class="toggle-btn" type="button" data-stylus-toggle aria-pressed="true">
                     <span class="toggle-btn__label">Stylus mode</span>
-                    <span id="stylusModeStatus" class="toggle-btn__status">Off</span>
+                    <span class="toggle-btn__status" data-stylus-status>On</span>
                 </button>
                 <p class="control-hint">Ignore accidental finger touches while drawing with a stylus.</p>
             </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,10 @@
 :root {
+    color-scheme: light dark;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+:root,
+:root[data-theme="light"] {
     color-scheme: light;
     --bg-gradient: radial-gradient(circle at top left, #eef2ff, #e0f2fe 45%, #f9fafb 100%);
     --page-overlay: radial-gradient(circle at 10% 20%, rgba(99, 102, 241, 0.12), transparent 45%),
@@ -34,7 +40,6 @@
     --focus-success: 0 0 0 6px rgba(16, 185, 129, 0.16);
     --focus-danger: 0 0 0 6px rgba(239, 68, 68, 0.16);
     --focus-muted: 0 0 0 6px rgba(148, 163, 184, 0.25);
-    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 :root[data-theme="dark"] {
@@ -73,6 +78,46 @@
     --focus-success: 0 0 0 6px rgba(52, 211, 153, 0.28);
     --focus-danger: 0 0 0 6px rgba(248, 113, 113, 0.28);
     --focus-muted: 0 0 0 6px rgba(148, 163, 184, 0.2);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) {
+        color-scheme: dark;
+        --bg-gradient: radial-gradient(circle at top left, #0b1120, #0f172a 55%, #111827 100%);
+        --page-overlay: radial-gradient(circle at 15% 20%, rgba(59, 130, 246, 0.25), transparent 45%),
+                        radial-gradient(circle at 85% 0%, rgba(14, 165, 233, 0.18), transparent 40%);
+        --surface: #111827;
+        --surface-muted: rgba(17, 24, 39, 0.72);
+        --surface-soft: rgba(148, 163, 184, 0.08);
+        --surface-strong: rgba(15, 23, 42, 0.8);
+        --border: rgba(148, 163, 184, 0.25);
+        --border-strong: rgba(148, 163, 184, 0.35);
+        --primary: #8b5cf6;
+        --primary-strong: #c4b5fd;
+        --primary-soft: rgba(139, 92, 246, 0.25);
+        --accent: #38bdf8;
+        --text-strong: #f8fafc;
+        --text-muted: #94a3b8;
+        --text-inverse: #0f172a;
+        --success: #34d399;
+        --danger: #f87171;
+        --shadow-primary: 0 14px 28px rgba(99, 102, 241, 0.45);
+        --shadow-primary-hover: 0 18px 36px rgba(129, 140, 248, 0.55);
+        --shadow-elevated: 0 14px 34px rgba(2, 6, 23, 0.55);
+        --shadow-card: 0 32px 70px rgba(2, 6, 23, 0.65);
+        --shadow-panel: 0 28px 64px rgba(2, 6, 23, 0.68);
+        --shadow-chip: 0 20px 48px rgba(2, 6, 23, 0.6);
+        --shadow-color-btn: 0 14px 24px rgba(2, 6, 23, 0.6);
+        --shadow-soft: 0 18px 32px rgba(129, 140, 248, 0.45);
+        --shadow-tool-active: 0 20px 38px rgba(129, 140, 248, 0.5);
+        --input-bg: rgba(30, 41, 59, 0.7);
+        --input-bg-focus: rgba(30, 41, 59, 0.95);
+        --range-track: rgba(129, 140, 248, 0.35);
+        --focus-primary: 0 0 0 6px rgba(129, 140, 248, 0.35);
+        --focus-success: 0 0 0 6px rgba(52, 211, 153, 0.28);
+        --focus-danger: 0 0 0 6px rgba(248, 113, 113, 0.28);
+        --focus-muted: 0 0 0 6px rgba(148, 163, 184, 0.2);
+    }
 }
 
 * {
@@ -768,10 +813,10 @@ input[type="range"]::-moz-range-thumb {
     position: absolute;
     right: clamp(0.9rem, 2.5vw, 1.5rem);
     bottom: clamp(0.9rem, 2.5vw, 1.5rem);
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem;
+    gap: 0.55rem;
+    padding: 0.45rem 0.6rem;
     border-radius: 999px;
     border: 1px solid var(--border-strong);
     background: rgba(255, 255, 255, 0.94);
@@ -779,11 +824,22 @@ input[type="range"]::-moz-range-thumb {
     backdrop-filter: blur(12px);
     transition: box-shadow 0.2s ease, transform 0.2s ease;
     z-index: 2;
+    flex-wrap: wrap;
 }
 
 .canvas-panel__quick-actions:hover {
     box-shadow: var(--shadow-soft);
     transform: translateY(-1px);
+}
+
+.quick-actions__cluster {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.quick-actions__cluster--stylus {
+    margin-left: 0.15rem;
 }
 
 .quick-action-btn {
@@ -882,6 +938,10 @@ input[type="range"]::-moz-range-thumb {
     height: 22px;
 }
 
+.canvas-panel__action-icon[hidden] {
+    display: none !important;
+}
+
 .canvas-wrapper {
     background: rgba(99, 102, 241, 0.08);
     border-radius: 20px;
@@ -893,6 +953,74 @@ input[type="range"]::-moz-range-thumb {
     min-height: clamp(320px, 55vh, 520px);
     transition: background 0.3s ease, box-shadow 0.3s ease;
     position: relative;
+}
+
+.canvas-topbar {
+    position: absolute;
+    top: clamp(1rem, 3vw, 2.1rem);
+    left: clamp(1rem, 3vw, 2.1rem);
+    right: clamp(1rem, 3vw, 2.1rem);
+    display: none;
+    align-items: center;
+    gap: clamp(0.6rem, 2vw, 1.1rem);
+    padding: 0.55rem clamp(0.6rem, 2vw, 1rem);
+    padding-right: calc(clamp(0.6rem, 2vw, 1rem) + 58px);
+    border-radius: 18px;
+    background: var(--surface-strong);
+    border: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-panel);
+    backdrop-filter: blur(14px);
+    flex-wrap: wrap;
+    z-index: 4;
+}
+
+.canvas-topbar--visible {
+    display: flex;
+}
+
+.canvas-topbar__section {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+}
+
+.canvas-topbar__section--colors .color-btn {
+    width: 36px;
+    height: 36px;
+}
+
+.canvas-topbar__section--history .quick-action-btn {
+    width: 38px;
+    height: 38px;
+}
+
+.canvas-topbar__section--tools .tool-btn {
+    min-width: max-content;
+}
+
+.canvas-topbar__section--stylus .toggle-btn--compact {
+    min-width: max-content;
+}
+
+.slider-field--topbar {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--surface-soft);
+    border-radius: 14px;
+    padding: 0.35rem 0.6rem;
+}
+
+.slider-field--topbar .chip-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+}
+
+.slider-field--topbar input[type="range"] {
+    width: clamp(120px, 18vw, 200px);
+    padding: 0;
+    background: var(--range-track);
 }
 
 .canvas-wrapper:hover {
@@ -923,6 +1051,7 @@ input[type="range"]::-moz-range-thumb {
     border-radius: 0;
     box-shadow: none;
     padding: clamp(1.5rem, 4vw, 3rem);
+    touch-action: none;
 }
 
 .canvas-panel:fullscreen .canvas-wrapper,
@@ -969,7 +1098,7 @@ input[type="range"]::-moz-range-thumb {
 
 .canvas-panel:fullscreen .canvas-panel__color-rail,
 .canvas-panel--fullscreen .canvas-panel__color-rail {
-    display: flex;
+    display: none;
 }
 
 .canvas-panel:fullscreen .canvas-panel__toolbar,
@@ -997,6 +1126,15 @@ input[type="range"]::-moz-range-thumb {
     right: clamp(1.2rem, 3vw, 2.25rem);
     bottom: clamp(1.2rem, 3vw, 2.25rem);
     padding: 0.45rem 0.55rem;
+}
+
+.canvas-panel:fullscreen [data-action="undo"],
+.canvas-panel--fullscreen [data-action="undo"],
+.canvas-panel:fullscreen [data-action="redo"],
+.canvas-panel--fullscreen [data-action="redo"],
+.canvas-panel:fullscreen .quick-actions__cluster--stylus,
+.canvas-panel--fullscreen .quick-actions__cluster--stylus {
+    display: none !important;
 }
 
 .canvas-panel:fullscreen .canvas-panel__action-btn,
@@ -1061,6 +1199,27 @@ input[type="range"]::-moz-range-thumb {
     }
 }
 
+@media (max-width: 720px) {
+    .canvas-topbar {
+        padding-right: calc(clamp(0.6rem, 5vw, 1rem) + 48px);
+        gap: 0.5rem;
+    }
+
+    .canvas-topbar__section--colors .color-btn {
+        width: 32px;
+        height: 32px;
+    }
+
+    .canvas-topbar__section--history .quick-action-btn {
+        width: 34px;
+        height: 34px;
+    }
+
+    .slider-field--topbar input[type="range"] {
+        width: clamp(110px, 40vw, 160px);
+    }
+}
+
 .control-panel {
     display: grid;
     gap: 1.5rem;
@@ -1110,7 +1269,6 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .tool-btn {
-    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1139,6 +1297,18 @@ input[type="range"]::-moz-range-thumb {
     box-shadow: var(--shadow-tool-active);
 }
 
+.quick-actions__cluster .tool-btn,
+.canvas-topbar__section--tools .tool-btn {
+    flex: 0 0 auto;
+    padding: 0.55rem 0.9rem;
+    border-radius: 14px;
+}
+
+.quick-actions__cluster .tool-btn__label,
+.canvas-topbar__section--tools .tool-btn__label {
+    font-size: 0.85rem;
+}
+
 .tool-btn__icon {
     width: 22px;
     height: 22px;
@@ -1163,6 +1333,13 @@ input[type="range"]::-moz-range-thumb {
     transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.toggle-btn--compact {
+    padding: 0.55rem 0.75rem;
+    border-radius: 14px;
+    gap: 0.6rem;
+    font-size: 0.85rem;
+}
+
 .toggle-btn:focus-visible {
     outline: none;
     box-shadow: var(--focus-primary);
@@ -1182,6 +1359,14 @@ input[type="range"]::-moz-range-thumb {
     font-size: 0.9rem;
     color: var(--text-muted);
     font-weight: 500;
+}
+
+.toggle-btn--compact .toggle-btn__label {
+    font-size: 0.85rem;
+}
+
+.toggle-btn--compact .toggle-btn__status {
+    font-size: 0.78rem;
 }
 
 .toggle-btn[aria-pressed="true"] .toggle-btn__status {
@@ -1225,6 +1410,92 @@ input[type="range"]::-moz-range-thumb {
     font-weight: 700;
     letter-spacing: 0.12em;
     color: var(--primary-strong);
+}
+
+@media (max-width: 900px) {
+    .page--student main {
+        padding: 0 clamp(1.25rem, 6vw, 2.5rem) 3.5rem;
+    }
+
+    .student-layout {
+        gap: clamp(1.5rem, 6vw, 2rem);
+    }
+
+    .canvas-panel {
+        padding: clamp(1.25rem, 4vw, 1.75rem);
+    }
+
+    .control-panel {
+        gap: 1.25rem;
+    }
+
+    .control-group {
+        padding: clamp(1.2rem, 4vw, 1.5rem);
+    }
+}
+
+@media (max-width: 640px) {
+    .page--student main {
+        padding: 0 clamp(1rem, 6vw, 1.5rem) 3rem;
+    }
+
+    .canvas-wrapper {
+        min-height: clamp(260px, 60vh, 420px);
+        padding: clamp(0.85rem, 4vw, 1.1rem);
+        border-radius: 18px;
+    }
+
+    .canvas-panel {
+        border-radius: 20px;
+    }
+
+    .canvas-panel__toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.85rem;
+    }
+
+    .canvas-panel__toolbar-actions {
+        width: 100%;
+        justify-items: center;
+    }
+
+    .canvas-panel__action-btn {
+        width: clamp(44px, 12vw, 48px);
+        height: clamp(44px, 12vw, 48px);
+    }
+
+    .control-panel {
+        position: relative;
+        top: auto;
+    }
+}
+
+@media (max-width: 480px) {
+    .page--student main {
+        padding: 0 clamp(0.75rem, 6vw, 1.25rem) 2.5rem;
+    }
+
+    .canvas-panel {
+        padding: clamp(1rem, 6vw, 1.25rem);
+        gap: 1rem;
+    }
+
+    .canvas-panel__titles {
+        gap: 0.3rem;
+    }
+
+    .canvas-panel__quick-actions {
+        gap: 0.3rem;
+    }
+
+    .control-panel {
+        gap: 1rem;
+    }
+
+    .control-group {
+        padding: clamp(1rem, 6vw, 1.25rem);
+    }
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
## Summary
- add a fullscreen canvas topbar that groups undo/redo, palette, brush controls, and stylus toggle while surfacing brush/eraser tools alongside the canvas
- default stylus mode to on, sync duplicate controls, and improve stylus detection heuristics for smoother pen input
- prevent unintended zoom/scroll on tablets by tightening viewport settings and touch-action handling

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d6322b2ba88327a843fc48a98fbff7