### PR TITLE
Refine student toolbar layout and input handling

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -27,6 +27,8 @@ const fullscreenEnterIcon = document.getElementById('fullscreenEnterIcon');
 const fullscreenExitIcon = document.getElementById('fullscreenExitIcon');
 const fullscreenToggleLabel = document.getElementById('fullscreenToggleLabel');
 const ctx = canvas.getContext('2d');
+const BASE_CANVAS_WIDTH = 800;
+const BASE_CANVAS_HEIGHT = 600;
 const colorButtons = Array.from(document.querySelectorAll('.color-btn'));
 const toolButtons = Array.from(document.querySelectorAll('[data-tool]'));
 const brushSizeInputs = Array.from(document.querySelectorAll('[data-brush-size]'));
@@ -39,8 +41,10 @@ const actionButtons = {
 };
 canvas.style.width = '100%';
 canvas.style.height = 'auto';
-canvas.width = 800;
-canvas.height = 600;
+canvas.width = BASE_CANVAS_WIDTH;
+canvas.height = BASE_CANVAS_HEIGHT;
+ctx.lineCap = 'round';
+ctx.lineJoin = 'round';
 ctx.fillStyle = '#ffffff';
 ctx.fillRect(0, 0, canvas.width, canvas.height);
 
@@ -58,6 +62,8 @@ let backgroundImageData = null;
 let backgroundImageElement = null;
 let stylusMode = true;
 let activePointerId = null;
+let viewportZoomLocked = false;
+let selectionGuardsInstalled = false;
 
 const supabaseUrl = window.SUPABASE_URL;
 const supabaseAnonKey = window.SUPABASE_ANON_KEY;
@@ -194,6 +200,14 @@ function announceStudent() {
 function setupControls() {
     if (!canvas) return;
 
+    lockViewportZoomForIOS();
+
+    if (!selectionGuardsInstalled) {
+        document.addEventListener('selectstart', preventPanelSelection);
+        document.addEventListener('dragstart', preventPanelSelection);
+        selectionGuardsInstalled = true;
+    }
+
     canvas.style.touchAction = 'none';
     if (canvasWrapper) {
         canvasWrapper.style.touchAction = 'none';
@@ -202,6 +216,10 @@ function setupControls() {
     if (canvasPanel) {
         canvasPanel.style.touchAction = 'none';
     }
+
+    canvas.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+    });
 
     if (window.PointerEvent) {
         canvas.addEventListener('pointerdown', startDrawing, { passive: false });
@@ -288,6 +306,12 @@ function setupControls() {
     setStylusMode(stylusMode);
 }
 
+function preventPanelSelection(event) {
+    if (event.target && event.target.closest('.canvas-panel')) {
+        event.preventDefault();
+    }
+}
+
 function setActiveColor(color) {
     if (!color) {
         return;
@@ -371,12 +395,6 @@ function setupFullscreenControls() {
         toggleFullscreen();
     });
 
-    if (canvasWrapper) {
-        canvasWrapper.addEventListener('dblclick', () => {
-            toggleFullscreen();
-        });
-    }
-
     const fullscreenEvents = ['fullscreenchange', 'webkitfullscreenchange', 'mozfullscreenchange', 'MSFullscreenChange'];
     fullscreenEvents.forEach((eventName) => {
         document.addEventListener(eventName, updateFullscreenUI);
@@ -437,8 +455,8 @@ function updateFullscreenUI() {
     }
 
     if (canvasTopbar) {
-        canvasTopbar.setAttribute('aria-hidden', String(!isFullscreen));
-        canvasTopbar.classList.toggle('canvas-topbar--visible', isFullscreen);
+        canvasTopbar.setAttribute('aria-hidden', 'false');
+        canvasTopbar.dataset.fullscreen = String(isFullscreen);
     }
 
     fullscreenToggle.setAttribute('aria-pressed', String(isFullscreen));
@@ -527,35 +545,49 @@ function drawStroke(event) {
         event.preventDefault();
     }
 
-    const { x, y } = getCanvasCoordinates(event);
+    const coalesced = typeof event.getCoalescedEvents === 'function'
+        ? event.getCoalescedEvents()
+        : null;
 
-    if (drawMode === 'draw' && currentPath) {
-        currentPath.points.push([x, y]);
+    const pointerEvents = Array.isArray(coalesced) && coalesced.length > 0
+        ? coalesced
+        : [event];
 
-        ctx.beginPath();
-        ctx.moveTo(lastX, lastY);
-        ctx.lineTo(x, y);
-        ctx.strokeStyle = currentColor;
-        ctx.lineWidth = currentWidth;
-        ctx.lineCap = 'round';
-        ctx.lineJoin = 'round';
-        ctx.stroke();
+    const batch = [];
 
-        sendDrawBatch([{
-            type: 'line',
-            startX: lastX,
-            startY: lastY,
-            endX: x,
-            endY: y,
-            width: currentWidth,
-            color: currentColor
-        }]);
-    } else if (drawMode === 'erase') {
-        checkErase(x, y);
+    pointerEvents.forEach((pointerEvent) => {
+        const { x, y } = getCanvasCoordinates(pointerEvent);
+
+        if (drawMode === 'draw' && currentPath) {
+            currentPath.points.push([x, y]);
+
+            ctx.beginPath();
+            ctx.moveTo(lastX, lastY);
+            ctx.lineTo(x, y);
+            ctx.strokeStyle = currentColor;
+            ctx.lineWidth = currentWidth;
+            ctx.stroke();
+
+            batch.push({
+                type: 'line',
+                startX: lastX,
+                startY: lastY,
+                endX: x,
+                endY: y,
+                width: currentWidth,
+                color: currentColor
+            });
+        } else if (drawMode === 'erase') {
+            checkErase(x, y);
+        }
+
+        lastX = x;
+        lastY = y;
+    });
+
+    if (batch.length > 0) {
+        sendDrawBatch(batch);
     }
-
-    lastX = x;
-    lastY = y;
 }
 
 function stopDrawing(event) {
@@ -858,8 +890,8 @@ function distToSegment(x, y, x1, y1, x2, y2) {
 
 function getCanvasCoordinates(event) {
     const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
+    const scaleX = BASE_CANVAS_WIDTH / rect.width;
+    const scaleY = BASE_CANVAS_HEIGHT / rect.height;
 
     if (event.type.includes('touch')) {
         const touch = event.touches[0] || event.changedTouches[0];
@@ -938,6 +970,48 @@ function shouldIgnoreEvent(event) {
     }
 
     return false;
+}
+
+function lockViewportZoomForIOS() {
+    if (viewportZoomLocked) {
+        return;
+    }
+
+    const userAgent = navigator.userAgent || '';
+    const isIOS = /iPad|iPhone|iPod/.test(userAgent)
+        || (userAgent.includes('Mac') && 'ontouchend' in document);
+
+    if (!isIOS) {
+        return;
+    }
+
+    const blockMultiTouch = (event) => {
+        if (event.touches && event.touches.length > 1) {
+            event.preventDefault();
+        }
+    };
+
+    const blockGesture = (event) => {
+        event.preventDefault();
+    };
+
+    let lastTouchEnd = 0;
+    const blockDoubleTap = (event) => {
+        const now = Date.now();
+        if (now - lastTouchEnd <= 350) {
+            event.preventDefault();
+        }
+        lastTouchEnd = now;
+    };
+
+    document.addEventListener('gesturestart', blockGesture, { passive: false });
+    document.addEventListener('gesturechange', blockGesture, { passive: false });
+    document.addEventListener('gestureend', blockGesture, { passive: false });
+    document.addEventListener('touchstart', blockMultiTouch, { passive: false });
+    document.addEventListener('touchmove', blockMultiTouch, { passive: false });
+    document.addEventListener('touchend', blockDoubleTap, { passive: false });
+
+    viewportZoomLocked = true;
 }
 
 function clonePaths(source) {

--- a/public/student.html
+++ b/public/student.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <title>Live Drawing Tool - Student Workspace</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -68,7 +68,7 @@
                 </div>
             </div>
             <div class="canvas-wrapper" id="canvasWrapper">
-                <div class="canvas-topbar" id="canvasTopbar" aria-hidden="true">
+                <div class="canvas-topbar" id="canvasTopbar" role="toolbar" aria-label="Drawing controls">
                     <div class="canvas-topbar__section canvas-topbar__section--history" role="group" aria-label="Canvas history">
                         <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
                             <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -80,6 +80,13 @@
                             <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <polyline points="15 3 21 9 15 15"></polyline>
                                 <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
+                            </svg>
+                        </button>
+                        <button class="quick-action-btn quick-action-btn--danger" type="button" data-action="clear" aria-label="Clear canvas" title="Clear canvas">
+                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M3 6h18"></path>
+                                <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6"></path>
+                                <path d="M10 6l1-3h2l1 3"></path>
                             </svg>
                         </button>
                     </div>
@@ -119,92 +126,8 @@
                     </div>
                 </div>
                 <canvas id="drawingCanvas"></canvas>
-                <div class="canvas-panel__quick-actions" aria-label="Canvas actions">
-                    <div class="quick-actions__cluster" role="group" aria-label="History">
-                        <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="9 15 3 9 9 3"></polyline>
-                                <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
-                            </svg>
-                        </button>
-                        <button class="quick-action-btn" type="button" data-action="redo" aria-label="Redo" title="Redo">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="15 3 21 9 15 15"></polyline>
-                                <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
-                            </svg>
-                        </button>
-                        <button class="quick-action-btn quick-action-btn--danger" type="button" data-action="clear" aria-label="Clear canvas" title="Clear canvas">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3 6h18"></path>
-                                <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6"></path>
-                                <path d="M10 6l1-3h2l1 3"></path>
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="quick-actions__cluster" role="group" aria-label="Drawing mode">
-                        <button class="tool-btn" type="button" data-tool="draw" aria-pressed="false">
-                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
-                                <path d="M14.75 6.04l3.21 3.21"></path>
-                            </svg>
-                            <span class="tool-btn__label">Brush</span>
-                        </button>
-                        <button class="tool-btn" type="button" data-tool="erase" aria-pressed="false">
-                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
-                                <path d="M6 19.5h7"></path>
-                            </svg>
-                            <span class="tool-btn__label">Eraser</span>
-                        </button>
-                    </div>
-                    <div class="quick-actions__cluster quick-actions__cluster--stylus" role="group" aria-label="Stylus mode">
-                        <button class="toggle-btn toggle-btn--compact" type="button" data-stylus-toggle aria-pressed="true">
-                            <span class="toggle-btn__label">Stylus</span>
-                            <span class="toggle-btn__status" data-stylus-status>On</span>
-                        </button>
-                    </div>
-                </div>
-            </div>
-            <div class="canvas-panel__color-rail" role="group" aria-label="Quick color markers">
-                <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
-                <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
-                <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
-                <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
             </div>
         </section>
-
-        <aside class="control-panel">
-            <div class="control-group">
-                <h2>Colors</h2>
-                <div class="color-buttons">
-                    <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
-                    <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
-                    <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
-                    <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
-                </div>
-            </div>
-
-            <div class="control-group">
-                <h2>Brush size</h2>
-                <label class="slider-field">
-                    <span class="chip-label">Adjust width</span>
-                    <input type="range" data-brush-size min="1" max="20" value="5">
-                </label>
-            </div>
-
-            <div class="control-group">
-                <h2>Input</h2>
-                <button class="toggle-btn" type="button" data-stylus-toggle aria-pressed="true">
-                    <span class="toggle-btn__label">Stylus mode</span>
-                    <span class="toggle-btn__status" data-stylus-status>On</span>
-                </button>
-                <p class="control-hint">Ignore accidental finger touches while drawing with a stylus.</p>
-            </div>
-
-            <div class="control-note">
-                <p>Your canvas is private to you and your teacher. We periodically sync so nothing gets lost.</p>
-            </div>
-        </aside>
     </main>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -180,7 +180,7 @@ button {
     border: none;
     border-radius: 12px;
     cursor: pointer;
-    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    transition: box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease;
 }
 
 .primary-btn {
@@ -193,7 +193,6 @@ button {
 
 .primary-btn:hover {
     background: var(--primary-strong);
-    transform: translateY(-2px);
     box-shadow: var(--shadow-primary-hover);
 }
 
@@ -208,7 +207,6 @@ button {
 
 .secondary-btn:hover {
     background: var(--surface-strong);
-    transform: translateY(-2px);
 }
 
 .ghost-btn {
@@ -241,13 +239,12 @@ button {
     align-items: center;
     justify-content: center;
     box-shadow: var(--shadow-elevated);
-    transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
     z-index: 5;
 }
 
 .theme-toggle:hover {
     background: var(--surface-strong);
-    transform: translateY(-2px);
 }
 
 .theme-toggle:focus-visible {
@@ -753,11 +750,17 @@ input[type="range"]::-moz-range-thumb {
     display: grid;
 }
 
+.page--student {
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: manipulation;
+    overscroll-behavior-y: contain;
+}
+
 .student-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) clamp(280px, 28vw, 360px);
+    display: flex;
+    flex-direction: column;
     gap: clamp(2rem, 6vw, 3rem);
-    align-items: start;
 }
 
 .canvas-panel {
@@ -809,38 +812,6 @@ input[type="range"]::-moz-range-thumb {
     align-items: center;
 }
 
-.canvas-panel__quick-actions {
-    position: absolute;
-    right: clamp(0.9rem, 2.5vw, 1.5rem);
-    bottom: clamp(0.9rem, 2.5vw, 1.5rem);
-    display: flex;
-    align-items: center;
-    gap: 0.55rem;
-    padding: 0.45rem 0.6rem;
-    border-radius: 999px;
-    border: 1px solid var(--border-strong);
-    background: rgba(255, 255, 255, 0.94);
-    box-shadow: var(--shadow-panel);
-    backdrop-filter: blur(12px);
-    transition: box-shadow 0.2s ease, transform 0.2s ease;
-    z-index: 2;
-    flex-wrap: wrap;
-}
-
-.canvas-panel__quick-actions:hover {
-    box-shadow: var(--shadow-soft);
-    transform: translateY(-1px);
-}
-
-.quick-actions__cluster {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-}
-
-.quick-actions__cluster--stylus {
-    margin-left: 0.15rem;
-}
 
 .quick-action-btn {
     display: inline-flex;
@@ -860,7 +831,6 @@ input[type="range"]::-moz-range-thumb {
 .quick-action-btn:hover {
     background: var(--primary-soft);
     color: var(--primary-strong);
-    transform: translateY(-1px);
 }
 
 .quick-action-btn:focus-visible {
@@ -882,11 +852,6 @@ input[type="range"]::-moz-range-thumb {
 .quick-action-btn__icon {
     width: 20px;
     height: 20px;
-}
-
-:root[data-theme="dark"] .canvas-panel__quick-actions {
-    background: rgba(15, 23, 42, 0.82);
-    border-color: rgba(148, 163, 184, 0.45);
 }
 
 .canvas-panel__titles {
@@ -920,7 +885,6 @@ input[type="range"]::-moz-range-thumb {
 
 .canvas-panel__action-btn:hover {
     background: var(--primary-strong);
-    transform: translateY(-2px);
     box-shadow: var(--shadow-primary-hover);
 }
 
@@ -942,40 +906,40 @@ input[type="range"]::-moz-range-thumb {
     display: none !important;
 }
 
+
 .canvas-wrapper {
     background: rgba(99, 102, 241, 0.08);
     border-radius: 20px;
     padding: clamp(1rem, 2vw, 1.4rem);
     box-shadow: inset 0 0 0 1px var(--border-strong), var(--shadow-panel);
     display: grid;
-    place-items: center;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    gap: clamp(0.75rem, 2vw, 1.15rem);
     width: 100%;
     min-height: clamp(320px, 55vh, 520px);
     transition: background 0.3s ease, box-shadow 0.3s ease;
     position: relative;
+    align-items: stretch;
+    overflow: hidden;
 }
 
 .canvas-topbar {
-    position: absolute;
-    top: clamp(1rem, 3vw, 2.1rem);
-    left: clamp(1rem, 3vw, 2.1rem);
-    right: clamp(1rem, 3vw, 2.1rem);
-    display: none;
+    grid-column: 1;
+    grid-row: 1;
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
-    gap: clamp(0.6rem, 2vw, 1.1rem);
-    padding: 0.55rem clamp(0.6rem, 2vw, 1rem);
-    padding-right: calc(clamp(0.6rem, 2vw, 1rem) + 58px);
+    gap: clamp(0.6rem, 2.5vw, 1rem);
+    padding: clamp(0.65rem, 2vw, 0.95rem) clamp(0.8rem, 2.2vw, 1.35rem);
     border-radius: 18px;
     background: var(--surface-strong);
     border: 1px solid var(--border-strong);
     box-shadow: var(--shadow-panel);
     backdrop-filter: blur(14px);
-    flex-wrap: wrap;
-    z-index: 4;
-}
-
-.canvas-topbar--visible {
-    display: flex;
+    z-index: 1;
+    position: sticky;
+    top: 0;
 }
 
 .canvas-topbar__section {
@@ -1044,7 +1008,19 @@ input[type="range"]::-moz-range-thumb {
     box-shadow: inset 0 0 0 1px var(--border-strong);
     background: #fff;
     touch-action: none;
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: stretch;
+    align-self: stretch;
 }
+
+@media (pointer: coarse) {
+    .canvas-topbar {
+        justify-content: space-between;
+        row-gap: clamp(0.75rem, 4vw, 1.35rem);
+    }
+}
+
 
 .canvas-panel:fullscreen,
 .canvas-panel--fullscreen {
@@ -1056,17 +1032,15 @@ input[type="range"]::-moz-range-thumb {
 
 .canvas-panel:fullscreen .canvas-wrapper,
 .canvas-panel--fullscreen .canvas-wrapper {
-    min-height: min(85vh, 100%);
+    padding: clamp(1rem, 3vw, 2rem);
+    min-height: 100%;
+    height: 100%;
 }
 
-.canvas-panel:fullscreen .canvas-panel__action-btn,
-.canvas-panel--fullscreen .canvas-panel__action-btn {
-    box-shadow: var(--shadow-primary-hover);
-}
-
-.canvas-panel:fullscreen .canvas-panel__action-btn:hover,
-.canvas-panel--fullscreen .canvas-panel__action-btn:hover {
-    transform: translateY(-1px);
+.canvas-panel:fullscreen .canvas-topbar,
+.canvas-panel--fullscreen .canvas-topbar {
+    top: clamp(0.5rem, 3vw, 1rem);
+    z-index: 5;
 }
 
 .canvas-panel:fullscreen .canvas-panel__subtitle,
@@ -1074,107 +1048,14 @@ input[type="range"]::-moz-range-thumb {
     display: none;
 }
 
-.canvas-panel__color-rail {
-    position: absolute;
-    top: 50%;
-    right: clamp(1rem, 4vw, 2.4rem);
-    transform: translateY(-50%);
-    background: var(--surface-strong);
-    border: 1px solid var(--border-strong);
-    border-radius: 999px;
-    padding: 0.75rem 0.6rem;
-    display: none;
-    flex-direction: column;
-    gap: 0.75rem;
-    box-shadow: var(--shadow-panel);
-    z-index: 3;
-}
-
-.canvas-panel__color-rail .color-btn {
-    width: 44px;
-    height: 44px;
-    box-shadow: var(--shadow-color-btn);
-}
-
-.canvas-panel:fullscreen .canvas-panel__color-rail,
-.canvas-panel--fullscreen .canvas-panel__color-rail {
-    display: none;
-}
-
-.canvas-panel:fullscreen .canvas-panel__toolbar,
-.canvas-panel--fullscreen .canvas-panel__toolbar {
-    position: absolute;
-    top: clamp(1rem, 4vw, 2.2rem);
-    right: clamp(1rem, 4vw, 2.2rem);
-    background: var(--surface-strong);
-    border-radius: 999px;
-    border: 1px solid var(--border-strong);
-    padding: 0.35rem;
-    box-shadow: var(--shadow-panel);
-    gap: 0;
-    pointer-events: none;
-    z-index: 3;
-}
-
-.canvas-panel:fullscreen .canvas-panel__toolbar-actions,
-.canvas-panel--fullscreen .canvas-panel__toolbar-actions {
-    pointer-events: auto;
-}
-
-.canvas-panel:fullscreen .canvas-panel__quick-actions,
-.canvas-panel--fullscreen .canvas-panel__quick-actions {
-    right: clamp(1.2rem, 3vw, 2.25rem);
-    bottom: clamp(1.2rem, 3vw, 2.25rem);
-    padding: 0.45rem 0.55rem;
-}
-
-.canvas-panel:fullscreen [data-action="undo"],
-.canvas-panel--fullscreen [data-action="undo"],
-.canvas-panel:fullscreen [data-action="redo"],
-.canvas-panel--fullscreen [data-action="redo"],
-.canvas-panel:fullscreen .quick-actions__cluster--stylus,
-.canvas-panel--fullscreen .quick-actions__cluster--stylus {
-    display: none !important;
-}
-
-.canvas-panel:fullscreen .canvas-panel__action-btn,
-.canvas-panel--fullscreen .canvas-panel__action-btn {
-    pointer-events: auto;
-}
-
-.canvas-panel:fullscreen .quick-action-btn,
-.canvas-panel--fullscreen .quick-action-btn {
-    pointer-events: auto;
-}
-
 .canvas-panel:fullscreen .canvas-panel__titles,
 .canvas-panel--fullscreen .canvas-panel__titles {
     display: none;
 }
 
-.canvas-panel:fullscreen .canvas-wrapper,
-.canvas-panel--fullscreen .canvas-wrapper {
-    padding: clamp(1rem, 3vw, 2rem);
-    min-height: 100%;
-    height: 100%;
-}
-
 .canvas-panel:fullscreen .canvas-wrapper canvas,
 .canvas-panel--fullscreen .canvas-wrapper canvas {
     max-height: none;
-}
-
-@media (max-width: 780px) {
-    .canvas-panel:fullscreen .canvas-panel__color-rail,
-    .canvas-panel--fullscreen .canvas-panel__color-rail {
-        flex-direction: row;
-        top: auto;
-        bottom: clamp(1rem, 6vw, 2.5rem);
-        left: 50%;
-        right: auto;
-        transform: translate(-50%, 0);
-        padding: 0.6rem 0.9rem;
-    }
 }
 
 @media (max-width: 900px) {
@@ -1191,18 +1072,12 @@ input[type="range"]::-moz-range-thumb {
         width: 100%;
         justify-items: stretch;
     }
-
-    .canvas-panel__quick-actions {
-        left: 50%;
-        right: auto;
-        transform: translate(-50%, 0);
-    }
 }
 
 @media (max-width: 720px) {
     .canvas-topbar {
-        padding-right: calc(clamp(0.6rem, 5vw, 1rem) + 48px);
-        gap: 0.5rem;
+        padding: clamp(0.6rem, 4vw, 0.85rem) clamp(0.7rem, 4vw, 1rem);
+        gap: clamp(0.4rem, 3vw, 0.75rem);
     }
 
     .canvas-topbar__section--colors .color-btn {
@@ -1218,28 +1093,6 @@ input[type="range"]::-moz-range-thumb {
     .slider-field--topbar input[type="range"] {
         width: clamp(110px, 40vw, 160px);
     }
-}
-
-.control-panel {
-    display: grid;
-    gap: 1.5rem;
-    position: sticky;
-    top: 1.5rem;
-    align-self: start;
-}
-
-.control-group {
-    background: var(--surface);
-    border-radius: 22px;
-    padding: 1.6rem;
-    box-shadow: var(--shadow-panel);
-    display: grid;
-    gap: 1rem;
-}
-
-.color-buttons {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .color-btn {
@@ -1258,14 +1111,8 @@ input[type="range"]::-moz-range-thumb {
 .color-btn.green { background: #10b981; }
 
 .color-btn.active {
-    transform: translateY(-2px) scale(1.05);
     border-color: var(--primary);
     box-shadow: var(--shadow-soft);
-}
-
-.mode-buttons {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .tool-btn {
@@ -1282,7 +1129,6 @@ input[type="range"]::-moz-range-thumb {
 }
 
 .tool-btn:hover {
-    transform: translateY(-1px);
     background: rgba(99, 102, 241, 0.2);
 }
 
@@ -1297,14 +1143,12 @@ input[type="range"]::-moz-range-thumb {
     box-shadow: var(--shadow-tool-active);
 }
 
-.quick-actions__cluster .tool-btn,
 .canvas-topbar__section--tools .tool-btn {
     flex: 0 0 auto;
     padding: 0.55rem 0.9rem;
     border-radius: 14px;
 }
 
-.quick-actions__cluster .tool-btn__label,
 .canvas-topbar__section--tools .tool-btn__label {
     font-size: 0.85rem;
 }
@@ -1424,14 +1268,6 @@ input[type="range"]::-moz-range-thumb {
     .canvas-panel {
         padding: clamp(1.25rem, 4vw, 1.75rem);
     }
-
-    .control-panel {
-        gap: 1.25rem;
-    }
-
-    .control-group {
-        padding: clamp(1.2rem, 4vw, 1.5rem);
-    }
 }
 
 @media (max-width: 640px) {
@@ -1464,11 +1300,6 @@ input[type="range"]::-moz-range-thumb {
         width: clamp(44px, 12vw, 48px);
         height: clamp(44px, 12vw, 48px);
     }
-
-    .control-panel {
-        position: relative;
-        top: auto;
-    }
 }
 
 @media (max-width: 480px) {
@@ -1484,32 +1315,9 @@ input[type="range"]::-moz-range-thumb {
     .canvas-panel__titles {
         gap: 0.3rem;
     }
-
-    .canvas-panel__quick-actions {
-        gap: 0.3rem;
-    }
-
-    .control-panel {
-        gap: 1rem;
-    }
-
-    .control-group {
-        padding: clamp(1rem, 6vw, 1.25rem);
-    }
 }
 
 /* Responsive adjustments */
-@media (max-width: 1024px) {
-    .student-layout {
-        grid-template-columns: 1fr;
-    }
-
-    .control-panel {
-        position: relative;
-        top: auto;
-    }
-}
-
 @media (max-width: 720px) {
     .theme-toggle {
         top: 1rem;
@@ -1553,29 +1361,5 @@ input[type="range"]::-moz-range-thumb {
 
     .copy-url button {
         width: 100%;
-    }
-
-    .color-buttons {
-        flex-wrap: wrap;
-    }
-
-    .mode-buttons {
-        flex-direction: column;
-    }
-
-    .canvas-panel__quick-actions {
-        left: clamp(0.7rem, 6vw, 1.25rem);
-        right: clamp(0.7rem, 6vw, 1.25rem);
-        bottom: clamp(0.7rem, 6vw, 1.25rem);
-        transform: none;
-        padding: 0.35rem 0.4rem;
-        gap: 0.35rem;
-        justify-content: space-between;
-    }
-
-    .quick-action-btn {
-        width: 100%;
-        height: 40px;
-        flex: 1;
     }
 }


### PR DESCRIPTION
## Summary
- collapse the student drawing controls into a single sticky toolbar, remove the side panel, and restore the inline clear action
- update student workspace styling to keep the toolbar fixed, free the canvas width, and suppress accidental text selection while drawing
- harden input handling by blocking stray selection/context gestures and requiring the fullscreen toggle button for exiting focus mode

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d64e08e2788327b26bdf217dfcc398