### PR TITLE
Reorient student toolbar horizontally

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -49,78 +49,10 @@
                     <h2 class="canvas-panel__title">Creative canvas</h2>
                     <p class="canvas-panel__subtitle">Go full screen for focus mode and extra drawing space.</p>
                 </div>
-                <div class="canvas-panel__toolbar-actions">
-                    <button id="fullscreenToggle" class="canvas-panel__action-btn" type="button" aria-pressed="false" aria-label="Enter fullscreen" title="Enter fullscreen">
-                        <svg id="fullscreenEnterIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <polyline points="5 9 5 5 9 5"></polyline>
-                            <polyline points="19 15 19 19 15 19"></polyline>
-                            <polyline points="15 5 19 5 19 9"></polyline>
-                            <polyline points="9 19 5 19 5 15"></polyline>
-                        </svg>
-                        <svg id="fullscreenExitIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden>
-                            <polyline points="9 5 5 5 5 9"></polyline>
-                            <polyline points="15 19 19 19 19 15"></polyline>
-                            <polyline points="19 9 19 5 15 5"></polyline>
-                            <polyline points="5 15 5 19 9 19"></polyline>
-                        </svg>
-                        <span id="fullscreenToggleLabel" class="visually-hidden">Enter fullscreen</span>
-                    </button>
-                </div>
             </div>
-            <div class="canvas-wrapper" id="canvasWrapper">
-                <div class="canvas-topbar" id="canvasTopbar" aria-hidden="false">
-                    <div class="canvas-topbar__section canvas-topbar__section--history" role="group" aria-label="Canvas history">
-                        <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="9 15 3 9 9 3"></polyline>
-                                <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
-                            </svg>
-                        </button>
-                        <button class="quick-action-btn" type="button" data-action="redo" aria-label="Redo" title="Redo">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="15 3 21 9 15 15"></polyline>
-                                <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="canvas-topbar__section canvas-topbar__section--colors" role="group" aria-label="Top bar colors">
-                        <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
-                        <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
-                        <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
-                        <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
-                    </div>
-                    <div class="canvas-topbar__section canvas-topbar__section--tools" role="group" aria-label="Drawing mode">
-                        <button class="tool-btn" type="button" data-tool="draw" aria-pressed="false">
-                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
-                                <path d="M14.75 6.04l3.21 3.21"></path>
-                            </svg>
-                            <span class="tool-btn__label">Brush</span>
-                        </button>
-                        <button class="tool-btn" type="button" data-tool="erase" aria-pressed="false">
-                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
-                                <path d="M6 19.5h7"></path>
-                            </svg>
-                            <span class="tool-btn__label">Eraser</span>
-                        </button>
-                    </div>
-                    <div class="canvas-topbar__section canvas-topbar__section--brush">
-                        <label class="slider-field slider-field--topbar">
-                            <span class="chip-label">Brush size</span>
-                            <input type="range" data-brush-size min="1" max="20" value="5">
-                        </label>
-                    </div>
-                    <div class="canvas-topbar__section canvas-topbar__section--stylus">
-                        <button class="toggle-btn toggle-btn--compact" type="button" data-stylus-toggle aria-pressed="true">
-                            <span class="toggle-btn__label">Stylus mode</span>
-                            <span class="toggle-btn__status" data-stylus-status>On</span>
-                        </button>
-                    </div>
-                </div>
-                <canvas id="drawingCanvas"></canvas>
-                <div class="canvas-panel__quick-actions" aria-label="Canvas actions" aria-hidden="true" hidden>
-                    <div class="quick-actions__cluster" role="group" aria-label="History">
+            <div class="canvas-panel__layout">
+                <nav id="canvasToolbar" class="canvas-toolbar" aria-label="Canvas controls">
+                    <div class="canvas-toolbar__group canvas-toolbar__group--history" role="group" aria-label="History">
                         <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
                             <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <polyline points="9 15 3 9 9 3"></polyline>
@@ -141,7 +73,13 @@
                             </svg>
                         </button>
                     </div>
-                    <div class="quick-actions__cluster" role="group" aria-label="Drawing mode">
+                    <div class="canvas-toolbar__group canvas-toolbar__group--colors" role="group" aria-label="Colors">
+                        <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
+                        <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
+                        <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
+                        <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
+                    </div>
+                    <div class="canvas-toolbar__group canvas-toolbar__group--tools" role="group" aria-label="Drawing mode">
                         <button class="tool-btn" type="button" data-tool="draw" aria-pressed="false">
                             <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                 <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
@@ -157,54 +95,42 @@
                             <span class="tool-btn__label">Eraser</span>
                         </button>
                     </div>
-                    <div class="quick-actions__cluster quick-actions__cluster--stylus" role="group" aria-label="Stylus mode">
+                    <div class="canvas-toolbar__group canvas-toolbar__group--brush" role="group" aria-label="Brush size">
+                        <label class="slider-field slider-field--inline">
+                            <span class="chip-label">Brush size</span>
+                            <input type="range" data-brush-size min="1" max="20" value="5">
+                        </label>
+                    </div>
+                    <div class="canvas-toolbar__group canvas-toolbar__group--stylus" role="group" aria-label="Stylus mode">
                         <button class="toggle-btn toggle-btn--compact" type="button" data-stylus-toggle aria-pressed="true">
                             <span class="toggle-btn__label">Stylus</span>
                             <span class="toggle-btn__status" data-stylus-status>On</span>
                         </button>
                     </div>
+                    <div class="canvas-toolbar__spacer" aria-hidden="true"></div>
+                    <div class="canvas-toolbar__group canvas-toolbar__group--fullscreen" role="group" aria-label="Canvas layout">
+                        <button id="fullscreenToggle" class="canvas-panel__action-btn canvas-panel__action-btn--vertical" type="button" aria-pressed="false" aria-label="Enter fullscreen" title="Enter fullscreen">
+                            <svg id="fullscreenEnterIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <polyline points="5 9 5 5 9 5"></polyline>
+                                <polyline points="19 15 19 19 15 19"></polyline>
+                                <polyline points="15 5 19 5 19 9"></polyline>
+                                <polyline points="9 19 5 19 5 15"></polyline>
+                            </svg>
+                            <svg id="fullscreenExitIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden>
+                                <polyline points="9 5 5 5 5 9"></polyline>
+                                <polyline points="15 19 19 19 19 15"></polyline>
+                                <polyline points="19 9 19 5 15 5"></polyline>
+                                <polyline points="5 15 5 19 9 19"></polyline>
+                            </svg>
+                            <span id="fullscreenToggleLabel" class="visually-hidden">Enter fullscreen</span>
+                        </button>
+                    </div>
+                </nav>
+                <div class="canvas-wrapper" id="canvasWrapper">
+                    <canvas id="drawingCanvas"></canvas>
                 </div>
-            </div>
-            <div class="canvas-panel__color-rail" role="group" aria-label="Quick color markers">
-                <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
-                <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
-                <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
-                <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
             </div>
         </section>
-
-        <aside class="control-panel">
-            <div class="control-group">
-                <h2>Colors</h2>
-                <div class="color-buttons">
-                    <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
-                    <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
-                    <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
-                    <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
-                </div>
-            </div>
-
-            <div class="control-group">
-                <h2>Brush size</h2>
-                <label class="slider-field">
-                    <span class="chip-label">Adjust width</span>
-                    <input type="range" data-brush-size min="1" max="20" value="5">
-                </label>
-            </div>
-
-            <div class="control-group">
-                <h2>Input</h2>
-                <button class="toggle-btn" type="button" data-stylus-toggle aria-pressed="true">
-                    <span class="toggle-btn__label">Stylus mode</span>
-                    <span class="toggle-btn__status" data-stylus-status>On</span>
-                </button>
-                <p class="control-hint">Ignore accidental finger touches while drawing with a stylus.</p>
-            </div>
-
-            <div class="control-note">
-                <p>Your canvas is private to you and your teacher. We periodically sync so nothing gets lost.</p>
-            </div>
-        </aside>
     </main>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -745,6 +745,11 @@ input[type="range"]::-moz-range-thumb {
 }
 
 /* Student workspace */
+.page--student {
+    user-select: none;
+    -webkit-user-select: none;
+}
+
 .page--student main {
     padding: 0 clamp(1.5rem, 5vw, 3.5rem) 4rem;
     display: grid;
@@ -752,9 +757,8 @@ input[type="range"]::-moz-range-thumb {
 
 .student-layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) clamp(280px, 28vw, 360px);
-    gap: clamp(2rem, 6vw, 3rem);
-    align-items: start;
+    grid-template-columns: minmax(0, 1fr);
+    gap: clamp(1.5rem, 5vw, 2.5rem);
 }
 
 .canvas-panel {
@@ -799,27 +803,6 @@ input[type="range"]::-moz-range-thumb {
     flex-wrap: wrap;
 }
 
-.canvas-panel__toolbar-actions {
-    display: grid;
-    gap: 0.75rem;
-    justify-items: end;
-    align-items: center;
-}
-
-
-.canvas-panel__quick-actions {
-    display: none !important;
-}
-
-.quick-actions__cluster {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-}
-
-.quick-actions__cluster--stylus {
-    margin-left: 0.15rem;
-}
 
 .quick-action-btn {
     display: inline-flex;
@@ -860,11 +843,6 @@ input[type="range"]::-moz-range-thumb {
 .quick-action-btn__icon {
     width: 20px;
     height: 20px;
-}
-
-:root[data-theme="dark"] .canvas-panel__quick-actions {
-    background: rgba(15, 23, 42, 0.82);
-    border-color: rgba(148, 163, 184, 0.45);
 }
 
 .canvas-panel__titles {
@@ -919,6 +897,93 @@ input[type="range"]::-moz-range-thumb {
     display: none !important;
 }
 
+.canvas-panel__layout {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.85rem, 2.5vw, 1.35rem);
+    align-items: stretch;
+    height: 100%;
+}
+
+.canvas-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: clamp(0.6rem, 2vw, 1rem);
+    padding: clamp(0.6rem, 1.8vw, 0.9rem) clamp(0.85rem, 2.5vw, 1.4rem);
+    border-radius: 18px;
+    background: var(--surface-strong);
+    border: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-panel);
+    width: 100%;
+    position: relative;
+    z-index: 2;
+}
+
+.canvas-toolbar__group {
+    display: flex;
+    align-items: center;
+    gap: clamp(0.45rem, 1.6vw, 0.85rem);
+}
+
+.canvas-toolbar__group--history,
+.canvas-toolbar__group--stylus,
+.canvas-toolbar__group--fullscreen {
+    flex-wrap: nowrap;
+}
+
+.canvas-toolbar__group--colors,
+.canvas-toolbar__group--tools {
+    gap: clamp(0.35rem, 1.4vw, 0.65rem);
+    flex-wrap: wrap;
+}
+
+.canvas-toolbar__group--brush {
+    min-width: clamp(180px, 35vw, 260px);
+}
+
+.canvas-toolbar__group--brush .slider-field {
+    width: 100%;
+}
+
+.slider-field {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.slider-field--inline {
+    justify-content: center;
+}
+
+.slider-field--inline .chip-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.slider-field--inline input[type="range"] {
+    width: clamp(140px, 28vw, 240px);
+    padding: 0;
+}
+
+.canvas-toolbar__spacer {
+    flex: 1 1 auto;
+    min-width: clamp(0.5rem, 3vw, 1.5rem);
+}
+
+.canvas-toolbar__group--fullscreen {
+    flex-shrink: 0;
+}
+
+.canvas-panel__action-btn--vertical {
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+}
+
 
 .canvas-wrapper {
     background: rgba(99, 102, 241, 0.08);
@@ -926,81 +991,12 @@ input[type="range"]::-moz-range-thumb {
     padding: clamp(1rem, 2vw, 1.4rem);
     box-shadow: inset 0 0 0 1px var(--border-strong), var(--shadow-panel);
     display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
-    gap: clamp(0.75rem, 2vw, 1.15rem);
     width: 100%;
+    flex: 1 1 auto;
     min-height: clamp(320px, 55vh, 520px);
     transition: background 0.3s ease, box-shadow 0.3s ease;
     position: relative;
     align-items: stretch;
-}
-
-.canvas-topbar {
-    grid-column: 1;
-    grid-row: 1;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: clamp(0.55rem, 2vw, 1rem);
-    padding: clamp(0.65rem, 2vw, 0.9rem) clamp(0.8rem, 2.2vw, 1.25rem);
-    border-radius: 18px;
-    background: var(--surface-strong);
-    border: 1px solid var(--border-strong);
-    box-shadow: var(--shadow-panel);
-    backdrop-filter: blur(14px);
-    z-index: 1;
-}
-
-.canvas-topbar__section {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    flex-wrap: wrap;
-}
-
-.canvas-topbar__section--colors .color-btn {
-    width: 36px;
-    height: 36px;
-}
-
-.canvas-topbar__section--history .quick-action-btn {
-    width: 38px;
-    height: 38px;
-}
-
-.canvas-topbar__section--tools .tool-btn {
-    min-width: max-content;
-}
-
-.canvas-topbar__section--stylus .toggle-btn--compact {
-    min-width: max-content;
-}
-
-@media (pointer: fine) {
-    .canvas-topbar__section--stylus {
-        margin-left: auto;
-    }
-}
-
-.slider-field--topbar {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: var(--surface-soft);
-    border-radius: 14px;
-    padding: 0.35rem 0.6rem;
-}
-
-.slider-field--topbar .chip-label {
-    font-size: 0.75rem;
-    letter-spacing: 0.16em;
-}
-
-.slider-field--topbar input[type="range"] {
-    width: clamp(120px, 18vw, 200px);
-    padding: 0;
-    background: var(--range-track);
 }
 
 .canvas-wrapper:hover {
@@ -1024,36 +1020,8 @@ input[type="range"]::-moz-range-thumb {
     box-shadow: inset 0 0 0 1px var(--border-strong);
     background: #fff;
     touch-action: none;
-    grid-column: 1;
-    grid-row: 2;
     justify-self: stretch;
     align-self: stretch;
-}
-
-@media (pointer: coarse) {
-    .canvas-wrapper {
-        grid-template-columns: minmax(200px, 30vw) 1fr;
-        grid-template-rows: 1fr;
-        align-items: stretch;
-    }
-
-    .canvas-topbar {
-        flex-direction: column;
-        align-items: stretch;
-        gap: clamp(0.65rem, 4vw, 1.25rem);
-        padding: clamp(0.75rem, 3.5vw, 1.35rem);
-        height: 100%;
-    }
-
-    .canvas-topbar__section {
-        width: 100%;
-        justify-content: flex-start;
-    }
-
-    .canvas-panel canvas {
-        grid-column: 2;
-        grid-row: 1;
-    }
 }
 
 .canvas-panel__color-rail {
@@ -1069,100 +1037,25 @@ input[type="range"]::-moz-range-thumb {
     touch-action: none;
 }
 
-.canvas-panel:fullscreen .canvas-wrapper,
-.canvas-panel--fullscreen .canvas-wrapper {
-    padding: clamp(1rem, 3vw, 2rem);
-    min-height: 100%;
+.canvas-panel:fullscreen .canvas-panel__layout,
+.canvas-panel--fullscreen .canvas-panel__layout {
     height: 100%;
 }
 
-.canvas-panel:fullscreen .canvas-topbar,
-.canvas-panel--fullscreen .canvas-topbar {
+.canvas-panel:fullscreen .canvas-toolbar,
+.canvas-panel--fullscreen .canvas-toolbar {
     position: sticky;
-    top: clamp(0.5rem, 3vw, 1rem);
+    top: 0;
     z-index: 5;
 }
 
-.canvas-panel:fullscreen .canvas-panel__subtitle,
-.canvas-panel--fullscreen .canvas-panel__subtitle {
-    display: none;
+.canvas-panel:fullscreen .canvas-wrapper,
+.canvas-panel--fullscreen .canvas-wrapper {
+    flex: 1 1 auto;
+    padding: clamp(1rem, 3vw, 2rem);
+    min-height: 0;
+    height: 100%;
 }
-
-.canvas-panel:fullscreen .canvas-panel__titles,
-.canvas-panel--fullscreen .canvas-panel__titles {
-    display: none;
-}
-
-.canvas-panel:fullscreen .canvas-wrapper canvas,
-.canvas-panel--fullscreen .canvas-wrapper canvas {
-    max-height: none;
-}
-
-@media (max-width: 900px) {
-    .canvas-panel__toolbar {
-        align-items: stretch;
-    }
-
-    .canvas-panel__action-btn {
-        width: 100%;
-        justify-content: center;
-    }
-
-    .canvas-panel__toolbar-actions {
-        width: 100%;
-        justify-items: stretch;
-    }
-
-    .canvas-panel__quick-actions {
-        left: 50%;
-        right: auto;
-        transform: translate(-50%, 0);
-    }
-}
-
-@media (max-width: 720px) {
-    .canvas-topbar {
-        padding: clamp(0.6rem, 4vw, 0.85rem) clamp(0.7rem, 4vw, 1rem);
-        gap: clamp(0.4rem, 3vw, 0.75rem);
-    }
-
-    .canvas-topbar__section--colors .color-btn {
-        width: 32px;
-        height: 32px;
-    }
-
-    .canvas-topbar__section--history .quick-action-btn {
-        width: 34px;
-        height: 34px;
-    }
-
-    .slider-field--topbar input[type="range"] {
-        width: clamp(110px, 40vw, 160px);
-    }
-}
-
-.control-panel {
-    display: grid;
-    gap: 1.5rem;
-    position: sticky;
-    top: 1.5rem;
-    align-self: start;
-}
-
-.control-group {
-    background: var(--surface);
-    border-radius: 22px;
-    padding: 1.6rem;
-    box-shadow: var(--shadow-panel);
-    display: grid;
-    gap: 1rem;
-}
-
-.color-buttons {
-    display: flex;
-    gap: 0.75rem;
-}
-
 .color-btn {
     width: 42px;
     height: 42px;
@@ -1181,11 +1074,6 @@ input[type="range"]::-moz-range-thumb {
 .color-btn.active {
     border-color: var(--primary);
     box-shadow: var(--shadow-soft);
-}
-
-.mode-buttons {
-    display: flex;
-    gap: 0.75rem;
 }
 
 .tool-btn {
@@ -1216,16 +1104,29 @@ input[type="range"]::-moz-range-thumb {
     box-shadow: var(--shadow-tool-active);
 }
 
-.quick-actions__cluster .tool-btn,
-.canvas-topbar__section--tools .tool-btn {
-    flex: 0 0 auto;
-    padding: 0.55rem 0.9rem;
+
+.canvas-toolbar__group--tools .tool-btn {
+    flex: 0 1 auto;
+    padding: 0.55rem 0.85rem;
     border-radius: 14px;
+    flex-direction: row;
+    justify-content: center;
 }
 
-.quick-actions__cluster .tool-btn__label,
-.canvas-topbar__section--tools .tool-btn__label {
-    font-size: 0.85rem;
+.canvas-toolbar__group--tools .tool-btn__label {
+    font-size: 0.9rem;
+    margin-top: 0;
+}
+
+.canvas-toolbar__group--colors .color-btn {
+    width: 36px;
+    height: 36px;
+}
+
+.canvas-toolbar__group--history .quick-action-btn,
+.canvas-toolbar__group--fullscreen .canvas-panel__action-btn--vertical {
+    width: 48px;
+    height: 48px;
 }
 
 .tool-btn__icon {
@@ -1331,62 +1232,92 @@ input[type="range"]::-moz-range-thumb {
     color: var(--primary-strong);
 }
 
-@media (max-width: 900px) {
+@media (max-width: 960px) {
     .page--student main {
-        padding: 0 clamp(1.25rem, 6vw, 2.5rem) 3.5rem;
+        padding: 0 clamp(1.2rem, 6vw, 2.5rem) 3.5rem;
     }
 
-    .student-layout {
-        gap: clamp(1.5rem, 6vw, 2rem);
+    .canvas-toolbar {
+        justify-content: center;
     }
 
-    .canvas-panel {
-        padding: clamp(1.25rem, 4vw, 1.75rem);
+    .canvas-toolbar__group--colors,
+    .canvas-toolbar__group--tools {
+        flex-wrap: wrap;
+        row-gap: 0.5rem;
     }
 
-    .control-panel {
-        gap: 1.25rem;
+    .canvas-toolbar__group {
+        flex-wrap: wrap;
+        justify-content: center;
     }
 
-    .control-group {
-        padding: clamp(1.2rem, 4vw, 1.5rem);
+    .canvas-toolbar__group--brush {
+        min-width: clamp(160px, 50vw, 280px);
+    }
+
+    .canvas-toolbar__spacer {
+        display: none;
     }
 }
 
 @media (max-width: 640px) {
-    .page--student main {
-        padding: 0 clamp(1rem, 6vw, 1.5rem) 3rem;
-    }
-
-    .canvas-wrapper {
-        min-height: clamp(260px, 60vh, 420px);
-        padding: clamp(0.85rem, 4vw, 1.1rem);
-        border-radius: 18px;
+    .student-layout {
+        gap: clamp(1.25rem, 7vw, 2rem);
     }
 
     .canvas-panel {
+        padding: clamp(1.1rem, 5vw, 1.5rem);
         border-radius: 20px;
+    }
+
+    .canvas-panel__titles {
+        gap: 0.35rem;
+    }
+
+    .canvas-panel__subtitle {
+        font-size: 0.9rem;
     }
 
     .canvas-panel__toolbar {
         flex-direction: column;
         align-items: stretch;
-        gap: 0.85rem;
     }
 
-    .canvas-panel__toolbar-actions {
+    .canvas-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+        gap: clamp(0.7rem, 3vw, 1rem);
+    }
+
+    .canvas-toolbar__group {
         width: 100%;
-        justify-items: center;
+        justify-content: center;
     }
 
-    .canvas-panel__action-btn {
-        width: clamp(44px, 12vw, 48px);
-        height: clamp(44px, 12vw, 48px);
+    .canvas-toolbar__group--colors,
+    .canvas-toolbar__group--tools {
+        flex-direction: row;
+        justify-content: center;
     }
 
-    .control-panel {
-        position: relative;
-        top: auto;
+    .canvas-toolbar__group--brush {
+        min-width: 0;
+    }
+
+    .slider-field--inline {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.4rem;
+    }
+
+    .slider-field--inline input[type="range"] {
+        width: 100%;
+    }
+
+    .canvas-panel__action-btn--vertical {
+        width: 48px;
+        height: 48px;
     }
 }
 
@@ -1402,30 +1333,6 @@ input[type="range"]::-moz-range-thumb {
 
     .canvas-panel__titles {
         gap: 0.3rem;
-    }
-
-    .canvas-panel__quick-actions {
-        gap: 0.3rem;
-    }
-
-    .control-panel {
-        gap: 1rem;
-    }
-
-    .control-group {
-        padding: clamp(1rem, 6vw, 1.25rem);
-    }
-}
-
-/* Responsive adjustments */
-@media (max-width: 1024px) {
-    .student-layout {
-        grid-template-columns: 1fr;
-    }
-
-    .control-panel {
-        position: relative;
-        top: auto;
     }
 }
 
@@ -1459,42 +1366,3 @@ input[type="range"]::-moz-range-thumb {
     }
 }
 
-@media (max-width: 540px) {
-    .theme-toggle {
-        width: 38px;
-        height: 38px;
-    }
-
-    .copy-url {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .copy-url button {
-        width: 100%;
-    }
-
-    .color-buttons {
-        flex-wrap: wrap;
-    }
-
-    .mode-buttons {
-        flex-direction: column;
-    }
-
-    .canvas-panel__quick-actions {
-        left: clamp(0.7rem, 6vw, 1.25rem);
-        right: clamp(0.7rem, 6vw, 1.25rem);
-        bottom: clamp(0.7rem, 6vw, 1.25rem);
-        transform: none;
-        padding: 0.35rem 0.4rem;
-        gap: 0.35rem;
-        justify-content: space-between;
-    }
-
-    .quick-action-btn {
-        width: 100%;
-        height: 40px;
-        flex: 1;
-    }
-}


### PR DESCRIPTION
## Summary
- move the student canvas controls into a single horizontal toolbar across the top of the workspace
- restyle the toolbar groups, brush slider, and fullscreen layout so tools share one row and adapt on smaller screens
- keep all existing actions (clear, undo/redo, stylus toggle, fullscreen) accessible without reintroducing the right column

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d659b5de6c8327990fa32e48526d54