### PR TITLE
Rebuild student canvas with iPad-style layout

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -8,115 +8,120 @@ if (!username || !sessionCode) {
 }
 
 const welcomeHeading = document.getElementById('welcomeHeading');
-const sessionBadge = document.getElementById('sessionStatus');
 const sessionCodeDisplay = document.getElementById('sessionCodeDisplay');
-
-if (welcomeHeading) {
-    welcomeHeading.textContent = `Hi, ${username}!`;
-}
-if (sessionCodeDisplay) {
-    sessionCodeDisplay.textContent = sessionCode;
-}
-
+const clearButton = document.getElementById('clearCanvasButton');
 const canvas = document.getElementById('drawingCanvas');
-const canvasPanel = document.getElementById('canvasPanel');
-const canvasWrapper = document.getElementById('canvasWrapper');
-const canvasToolbar = document.getElementById('canvasToolbar');
-const fullscreenToggle = document.getElementById('fullscreenToggle');
-const fullscreenEnterIcon = document.getElementById('fullscreenEnterIcon');
-const fullscreenExitIcon = document.getElementById('fullscreenExitIcon');
-const fullscreenToggleLabel = document.getElementById('fullscreenToggleLabel');
-const ctx = canvas.getContext('2d');
-const rootElement = document.documentElement;
-const FULLSCREEN_FOCUS_MODE = 'focus';
-const FULLSCREEN_NATIVE_MODE = 'native';
+const connectionLabel = document.getElementById('connectionLabel');
+const connectionIndicator = document.getElementById('connectionIndicator');
+const statusPill = document.getElementById('connectionStatus');
+
+const ctx = canvas?.getContext('2d', { alpha: false, desynchronized: true });
+
 const BASE_CANVAS_WIDTH = 800;
 const BASE_CANVAS_HEIGHT = 600;
-const colorButtons = Array.from(document.querySelectorAll('.color-btn'));
-const toolButtons = Array.from(document.querySelectorAll('[data-tool]'));
-const brushSizeInputs = Array.from(document.querySelectorAll('[data-brush-size]'));
-const stylusToggleButtons = Array.from(document.querySelectorAll('[data-stylus-toggle]'));
-const stylusStatusLabels = Array.from(document.querySelectorAll('[data-stylus-status]'));
-const actionButtons = {
-    undo: Array.from(document.querySelectorAll('[data-action="undo"]')),
-    redo: Array.from(document.querySelectorAll('[data-action="redo"]')),
-    clear: Array.from(document.querySelectorAll('[data-action="clear"]'))
-};
-
-document.addEventListener('selectstart', preventUnwantedSelection, { passive: false });
-document.addEventListener('dragstart', preventUnwantedSelection, { passive: false });
-canvas.style.width = '100%';
-canvas.style.height = 'auto';
-canvas.width = BASE_CANVAS_WIDTH;
-canvas.height = BASE_CANVAS_HEIGHT;
-ctx.lineCap = 'round';
-ctx.lineJoin = 'round';
-ctx.fillStyle = '#ffffff';
-ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-let isDrawing = false;
-let drawMode = 'draw';
-let currentColor = '#1e1b4b';
-let currentWidth = 5;
-let currentPath = null;
-let paths = [];
-let history = [];
-let currentStep = -1;
-let backgroundImageData = null;
-let backgroundImageElement = null;
-let stylusMode = true;
-let activePointerId = null;
-let viewportZoomLocked = false;
-let fullscreenExitRequestedByButton = false;
-let reentryScheduled = false;
-let hasEverEnteredFullscreen = false;
-let smoothStrokePoints = [];
-let lastStrokeEndpoint = null;
-let lastStrokePoint = null;
-let focusModeActive = false;
-let fullscreenStrategy = determineFullscreenStrategy();
-
-const supabaseUrl = window.SUPABASE_URL;
-const supabaseAnonKey = window.SUPABASE_ANON_KEY;
+const MAX_DPR = 3;
+const DRAW_BASE_WIDTH = 2.2;
+const DEFAULT_STROKE_COLOR = '#111827';
 
 let supabase;
 let channel;
 let channelReady = false;
-const presenceKey = `student-${username}-${Math.random().toString(36).slice(2, 10)}`;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-    setStatusBadge('Supabase configuration required', 'error');
-} else {
+let storedPaths = [];
+let backgroundImageData = null;
+let backgroundImageElement = null;
+
+const drawingState = {
+    isDrawing: false,
+    pointerId: null,
+    buffer: [],
+    history: [],
+    rafId: null
+};
+
+const canvasSize = {
+    width: 1,
+    height: 1
+};
+
+if (welcomeHeading) {
+    welcomeHeading.textContent = username ? `Hi, ${username}!` : 'Student canvas';
+}
+
+if (sessionCodeDisplay) {
+    sessionCodeDisplay.textContent = sessionCode || '----';
+}
+
+initialiseCanvas();
+setupClearButton();
+setupRealtime();
+
+function initialiseCanvas() {
+    if (!canvas || !ctx) {
+        return;
+    }
+
+    canvas.style.touchAction = 'none';
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    const resizeObserver = new ResizeObserver(() => {
+        requestAnimationFrame(resizeCanvas);
+    });
+    resizeObserver.observe(canvas);
+
+    window.addEventListener('orientationchange', () => {
+        setTimeout(resizeCanvas, 150);
+    });
+
+    canvas.addEventListener('pointerdown', handlePointerDown, { passive: false });
+    canvas.addEventListener('pointermove', handlePointerMove, { passive: false });
+    canvas.addEventListener('pointerup', handlePointerUp, { passive: false });
+    canvas.addEventListener('pointercancel', handlePointerCancel, { passive: false });
+    canvas.addEventListener('pointerleave', handlePointerCancel, { passive: false });
+
+    ['touchstart', 'touchmove', 'gesturestart'].forEach((eventName) => {
+        canvas.addEventListener(eventName, preventDefault, { passive: false });
+    });
+
+    resizeCanvas();
+}
+
+function setupClearButton() {
+    if (!clearButton) {
+        return;
+    }
+
+    clearButton.addEventListener('click', () => {
+        clearCanvas({ broadcast: true });
+    });
+}
+
+function setupRealtime() {
+    const supabaseUrl = window.SUPABASE_URL;
+    const supabaseAnonKey = window.SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+        setStatusBadge('Supabase configuration required', 'error');
+        return;
+    }
+
     initialiseRealtime().catch((error) => {
         console.error('Failed to initialise realtime connection', error);
         setStatusBadge('Realtime connection error', 'error');
     });
 }
 
-setupControls();
-setupFullscreenControls();
-initialiseHistory();
-
-function initialiseHistory() {
-    currentStep += 1;
-    history.push({
-        imageData: canvas.toDataURL(),
-        paths: [],
-        backgroundImage: backgroundImageData
-    });
-    updateButtons();
-}
-
 async function initialiseRealtime() {
     setStatusBadge('Connecting to Supabase...', 'pending');
-    supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY, {
         auth: { persistSession: false }
     });
 
     channel = supabase.channel(`session-${sessionCode}`, {
         config: {
             broadcast: { self: false },
-            presence: { key: presenceKey }
+            presence: { key: `student-${username}-${Math.random().toString(36).slice(2, 10)}` }
         }
     });
 
@@ -129,7 +134,7 @@ async function initialiseRealtime() {
 
             const { error } = await channel.track({ role: 'student', username });
             if (error) {
-                console.error('Failed to register presence', error);
+                console.error('Failed to register student presence', error);
             }
 
             announceStudent();
@@ -149,6 +154,10 @@ async function initialiseRealtime() {
 }
 
 function wireChannelEvents() {
+    if (!channel) {
+        return;
+    }
+
     channel.on('presence', { event: 'sync' }, () => {
         const presenceState = channel.presenceState();
         const teacherOnline = Object.values(presenceState).some((entries) =>
@@ -167,8 +176,7 @@ function wireChannelEvents() {
     });
 
     channel.on('broadcast', { event: 'request_canvas' }, ({ payload }) => {
-        const { target } = payload || {};
-        if (target === username) {
+        if (payload?.target === username) {
             broadcastCanvas('sync');
         }
     });
@@ -183,12 +191,11 @@ function wireChannelEvents() {
             return;
         }
 
-        if (typeof imageData !== 'string' || imageData.length === 0) {
+        if (typeof imageData === 'string' && imageData.length > 0) {
+            applyBackgroundImage(imageData);
+        } else {
             removeBackgroundImage();
-            return;
         }
-
-        applyBackgroundImage(imageData);
     });
 
     channel.on('broadcast', { event: 'next_question' }, () => {
@@ -208,521 +215,63 @@ function announceStudent() {
     safeSend('student_ready', { username });
 }
 
-function setupControls() {
-    if (!canvas) return;
-
-    lockViewportZoomForIOS();
-
-    canvas.style.touchAction = 'none';
-    if (canvasWrapper) {
-        canvasWrapper.style.touchAction = 'none';
-    }
-
-    if (canvasPanel) {
-        canvasPanel.style.touchAction = 'none';
-    }
-
-    if (window.PointerEvent) {
-        canvas.addEventListener('pointerdown', startDrawing, { passive: false });
-        canvas.addEventListener('pointermove', drawStroke, { passive: false });
-        canvas.addEventListener('pointerup', stopDrawing, { passive: false });
-        canvas.addEventListener('pointercancel', stopDrawing, { passive: false });
-        canvas.addEventListener('pointerout', stopDrawing, { passive: false });
-    } else {
-        canvas.addEventListener('mousedown', startDrawing);
-        canvas.addEventListener('mousemove', drawStroke);
-        canvas.addEventListener('mouseup', stopDrawing);
-        canvas.addEventListener('mouseout', stopDrawing);
-
-        canvas.addEventListener('touchstart', startDrawing, { passive: false });
-        canvas.addEventListener('touchmove', drawStroke, { passive: false });
-        canvas.addEventListener('touchend', stopDrawing, { passive: false });
-        canvas.addEventListener('touchcancel', stopDrawing, { passive: false });
-    }
-
-    colorButtons.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            if (!btn.dataset.color) {
-                return;
-            }
-            setActiveColor(btn.dataset.color);
-            setTool('draw');
-        });
-    });
-
-    brushSizeInputs.forEach((input) => {
-        input.addEventListener('input', (event) => {
-            const value = parseInt(event.target.value, 10) || 5;
-            currentWidth = value;
-            syncBrushSizeInputs(event.target, value);
-        });
-    });
-
-    toolButtons.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            const { tool } = btn.dataset;
-            if (!tool) {
-                return;
-            }
-            setTool(tool);
-        });
-    });
-
-    actionButtons.clear.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            paths = [];
-            redrawCanvas();
-            pushHistory();
-            broadcastCanvas('clear');
-        });
-    });
-
-    actionButtons.undo.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            if (currentStep <= 0) return;
-            currentStep -= 1;
-            restoreFromHistory(history[currentStep]);
-            broadcastCanvas('undo');
-        });
-    });
-
-    actionButtons.redo.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            if (currentStep >= history.length - 1) return;
-            currentStep += 1;
-            restoreFromHistory(history[currentStep]);
-            broadcastCanvas('redo');
-        });
-    });
-
-    stylusToggleButtons.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            setStylusMode(!stylusMode);
-        });
-    });
-
-    syncBrushSizeInputs(null, currentWidth);
-    setActiveColor(currentColor);
-    setTool(drawMode);
-    setStylusMode(stylusMode);
-}
-
-function setActiveColor(color) {
-    if (!color) {
+function handlePointerDown(event) {
+    if (!canvas || !ctx || !isSupportedPointer(event)) {
         return;
     }
 
-    currentColor = color;
-    updateColorUI();
-}
+    event.preventDefault();
 
-function updateColorUI() {
-    colorButtons.forEach((btn) => {
-        if (!btn?.dataset?.color) {
-            return;
-        }
-
-        const isActive = drawMode === 'draw' && btn.dataset.color === currentColor;
-        btn.classList.toggle('active', isActive);
-    });
-}
-
-function syncBrushSizeInputs(sourceInput, value) {
-    brushSizeInputs.forEach((input) => {
-        if (!input) {
-            return;
-        }
-
-        if (input !== sourceInput) {
-            input.value = value;
-        }
-
-        input.setAttribute('aria-valuenow', String(value));
-    });
-}
-
-function setTool(tool) {
-    const nextMode = tool === 'erase' ? 'erase' : 'draw';
-    drawMode = nextMode;
-
-    toolButtons.forEach((btn) => {
-        if (!btn?.dataset?.tool) {
-            return;
-        }
-
-        const isActive = btn.dataset.tool === nextMode;
-        btn.classList.toggle('active', isActive);
-        btn.setAttribute('aria-pressed', String(isActive));
-    });
-
-    if (drawMode === 'draw') {
-        updateColorUI();
-    } else {
-        colorButtons.forEach((btn) => btn.classList.remove('active'));
-    }
-}
-
-function setStylusMode(enabled) {
-    stylusMode = Boolean(enabled);
-
-    stylusToggleButtons.forEach((btn) => {
-        if (!btn) {
-            return;
-        }
-
-        btn.setAttribute('aria-pressed', String(stylusMode));
-        btn.classList.toggle('active', stylusMode);
-    });
-
-    stylusStatusLabels.forEach((label) => {
-        if (label) {
-            label.textContent = stylusMode ? 'On' : 'Off';
-        }
-    });
-}
-
-function setupFullscreenControls() {
-    if (!canvasPanel || !fullscreenToggle) {
-        return;
-    }
-
-    fullscreenToggle.addEventListener('click', () => {
-        toggleFullscreen();
-    });
-
-    const fullscreenEvents = ['fullscreenchange', 'webkitfullscreenchange', 'mozfullscreenchange', 'MSFullscreenChange'];
-    fullscreenEvents.forEach((eventName) => {
-        document.addEventListener(eventName, updateFullscreenUI);
-    });
-
-    document.addEventListener('keydown', handleFullscreenKeydown);
-
-    updateFullscreenUI();
-}
-
-function toggleFullscreen() {
-    if (fullscreenStrategy === FULLSCREEN_FOCUS_MODE) {
-        focusModeActive = !focusModeActive;
-        updateFullscreenUI();
-        return;
-    }
-
-    if (isCanvasFullscreen()) {
-        fullscreenExitRequestedByButton = true;
-        exitFullscreen();
-    } else {
-        enterFullscreen();
-    }
-}
-
-function enterFullscreen() {
-    if (!canvasPanel) return;
-
-    if (fullscreenStrategy === FULLSCREEN_FOCUS_MODE) {
-        if (!focusModeActive) {
-            focusModeActive = true;
-            updateFullscreenUI();
-        }
-        return;
-    }
-
-    const request = canvasPanel.requestFullscreen
-        || canvasPanel.webkitRequestFullscreen
-        || canvasPanel.mozRequestFullScreen
-        || canvasPanel.msRequestFullscreen;
-
-    if (request) {
+    if (typeof event.pointerId === 'number' && typeof canvas.setPointerCapture === 'function') {
         try {
-            const result = request.call(canvasPanel);
-            if (result && typeof result.then === 'function') {
-                result.catch((error) => {
-                    console.error('Failed to enter fullscreen', error);
-                    fallbackToFocusMode();
-                });
-            }
+            canvas.setPointerCapture(event.pointerId);
         } catch (error) {
-            console.error('Failed to enter fullscreen', error);
-            fallbackToFocusMode();
-        }
-    } else {
-        fallbackToFocusMode();
-    }
-}
-
-function exitFullscreen() {
-    if (fullscreenStrategy === FULLSCREEN_FOCUS_MODE) {
-        if (focusModeActive) {
-            focusModeActive = false;
-            updateFullscreenUI();
-        }
-        return;
-    }
-
-    const exit = document.exitFullscreen
-        || document.webkitExitFullscreen
-        || document.mozCancelFullScreen
-        || document.msExitFullscreen;
-
-    if (exit) {
-        try {
-            const result = exit.call(document);
-            if (result && typeof result.then === 'function') {
-                result.catch((error) => {
-                    console.error('Failed to exit fullscreen', error);
-                    fullscreenExitRequestedByButton = false;
-                });
-            }
-        } catch (error) {
-            console.error('Failed to exit fullscreen', error);
-            fullscreenExitRequestedByButton = false;
-        }
-    } else if (focusModeActive) {
-        focusModeActive = false;
-        updateFullscreenUI();
-    }
-}
-
-function updateFullscreenUI() {
-    if (!fullscreenToggle) {
-        return;
-    }
-
-    const nativeFullscreenActive = isCanvasFullscreen();
-    const isFullscreen = nativeFullscreenActive || focusModeActive;
-    const inFocusMode = focusModeActive && !nativeFullscreenActive;
-    const preferredLabel = inFocusMode || fullscreenStrategy === FULLSCREEN_FOCUS_MODE ? 'focus mode' : 'fullscreen';
-
-    if (canvasPanel) {
-        canvasPanel.classList.toggle('canvas-panel--fullscreen', isFullscreen);
-    }
-
-    if (canvasToolbar) {
-        canvasToolbar.dataset.fullscreen = String(isFullscreen);
-    }
-
-    if (document.body) {
-        document.body.classList.toggle('canvas-fullscreen-active', isFullscreen);
-    }
-
-    if (rootElement) {
-        rootElement.classList.toggle('canvas-fullscreen-active', isFullscreen);
-    }
-
-    fullscreenToggle.setAttribute('aria-pressed', String(isFullscreen));
-    fullscreenToggle.setAttribute('aria-label', isFullscreen ? `Exit ${preferredLabel}` : `Enter ${preferredLabel}`);
-    fullscreenToggle.title = isFullscreen ? `Exit ${preferredLabel}` : `Enter ${preferredLabel}`;
-
-    if (fullscreenToggleLabel) {
-        fullscreenToggleLabel.textContent = isFullscreen ? `Exit ${preferredLabel}` : `Enter ${preferredLabel}`;
-    }
-
-    if (fullscreenEnterIcon) {
-        fullscreenEnterIcon.hidden = isFullscreen;
-    }
-
-    if (fullscreenExitIcon) {
-        fullscreenExitIcon.hidden = !isFullscreen;
-    }
-
-    if (nativeFullscreenActive) {
-        hasEverEnteredFullscreen = true;
-    } else {
-        if (fullscreenStrategy === FULLSCREEN_NATIVE_MODE) {
-            if (hasEverEnteredFullscreen && !fullscreenExitRequestedByButton && canvasPanel && !reentryScheduled) {
-                reentryScheduled = true;
-                requestAnimationFrame(() => {
-                    reentryScheduled = false;
-                    enterFullscreen();
-                });
-            }
-            fullscreenExitRequestedByButton = false;
-        } else {
-            fullscreenExitRequestedByButton = false;
+            console.warn('Failed to capture pointer', error);
         }
     }
+
+    drawingState.isDrawing = true;
+    drawingState.pointerId = typeof event.pointerId === 'number' ? event.pointerId : null;
+    drawingState.buffer = [];
+    drawingState.history = [];
+
+    const point = getCanvasPoint(event);
+    addPointToStroke(point);
 }
 
-function isCanvasFullscreen() {
-    const fullscreenElement = document.fullscreenElement
-        || document.webkitFullscreenElement
-        || document.mozFullScreenElement
-        || document.msFullscreenElement;
-
-    return fullscreenElement === canvasPanel;
-}
-
-function fallbackToFocusMode() {
-    fullscreenStrategy = FULLSCREEN_FOCUS_MODE;
-    if (!focusModeActive) {
-        focusModeActive = true;
-    }
-    fullscreenExitRequestedByButton = false;
-    updateFullscreenUI();
-}
-
-function handleFullscreenKeydown(event) {
-    if (!event) {
+function handlePointerMove(event) {
+    if (!canvas || !ctx || !drawingState.isDrawing) {
         return;
     }
 
-    if (event.key === 'Escape' && fullscreenStrategy === FULLSCREEN_FOCUS_MODE && focusModeActive) {
-        focusModeActive = false;
-        updateFullscreenUI();
-    }
-}
-
-function determineFullscreenStrategy() {
-    if (!canvasPanel) {
-        return FULLSCREEN_FOCUS_MODE;
-    }
-
-    if (isIOSDevice()) {
-        return FULLSCREEN_FOCUS_MODE;
-    }
-
-    if (!hasNativeFullscreenSupport()) {
-        return FULLSCREEN_FOCUS_MODE;
-    }
-
-    return FULLSCREEN_NATIVE_MODE;
-}
-
-function hasNativeFullscreenSupport() {
-    if (!canvasPanel) {
-        return false;
-    }
-
-    const request = canvasPanel.requestFullscreen
-        || canvasPanel.webkitRequestFullscreen
-        || canvasPanel.mozRequestFullScreen
-        || canvasPanel.msRequestFullscreen;
-
-    return typeof request === 'function';
-}
-
-function isIOSDevice() {
-    if (typeof navigator === 'undefined') {
-        return false;
-    }
-
-    const platform = navigator.platform || '';
-    const userAgent = navigator.userAgent || '';
-    const isAppleTouchDevice = /iP(ad|hone|od)/.test(userAgent);
-    const isMacWithTouch = platform === 'MacIntel' && navigator.maxTouchPoints > 1;
-
-    return isAppleTouchDevice || isMacWithTouch;
-}
-
-function startDrawing(event) {
-    if (shouldIgnoreEvent(event)) {
+    if (typeof event.pointerId === 'number' && drawingState.pointerId !== null && event.pointerId !== drawingState.pointerId) {
         return;
     }
 
-    if (event?.preventDefault) {
-        event.preventDefault();
+    if (!isSupportedPointer(event)) {
+        return;
     }
 
-    if (typeof event?.pointerId === 'number') {
-        activePointerId = event.pointerId;
-        if (typeof canvas.setPointerCapture === 'function') {
-            try {
-                canvas.setPointerCapture(activePointerId);
-            } catch (error) {
-                console.warn('Failed to capture pointer', error);
-            }
-        }
-    } else {
-        activePointerId = null;
-    }
-
-    const sample = createStrokeSample(event);
-    const { x, y } = sample;
-    isDrawing = true;
-
-    if (drawMode === 'draw') {
-        currentPath = {
-            color: currentColor,
-            width: currentWidth,
-            points: [[x, y, sample.p]]
-        };
-
-        smoothStrokePoints = [sample];
-        lastStrokeEndpoint = { x, y };
-        lastStrokePoint = sample;
-
-        ctx.beginPath();
-        ctx.arc(x, y, currentWidth / 2, 0, Math.PI * 2);
-        ctx.fillStyle = currentColor;
-        ctx.fill();
-
-        sendDrawBatch([{ type: 'dot', x, y, radius: currentWidth / 2, color: currentColor }]);
-    } else if (drawMode === 'erase') {
-        checkErase(x, y);
-    }
+    event.preventDefault();
+    addPointToStroke(getCanvasPoint(event));
 }
 
-function drawStroke(event) {
-    if (!isDrawing) return;
-
-    if (typeof event?.pointerId === 'number' && activePointerId !== null && event.pointerId !== activePointerId) {
+function handlePointerUp(event) {
+    if (!canvas || !ctx || !drawingState.isDrawing) {
         return;
     }
 
-    if (shouldIgnoreEvent(event)) {
+    if (typeof event.pointerId === 'number' && drawingState.pointerId !== null && event.pointerId !== drawingState.pointerId) {
         return;
     }
 
-    if (event?.preventDefault) {
-        event.preventDefault();
-    }
-
-    const coalesced = typeof event.getCoalescedEvents === 'function'
-        ? event.getCoalescedEvents()
-        : null;
-
-    const pointerEvents = Array.isArray(coalesced) && coalesced.length > 0
-        ? coalesced
-        : [event];
-
-    const batch = [];
-
-    pointerEvents.forEach((pointerEvent) => {
-        if (drawMode === 'draw' && currentPath) {
-            const sample = createStrokeSample(pointerEvent);
-            currentPath.points.push([sample.x, sample.y, sample.p]);
-            smoothStrokePoints.push(sample);
-
-            const { segments, remainingPoints } = drawSmoothSegments(smoothStrokePoints, currentColor, currentWidth);
-            smoothStrokePoints = remainingPoints;
-
-            if (segments.length > 0) {
-                batch.push(...segments);
-            }
-
-            lastStrokePoint = sample;
-        } else if (drawMode === 'erase') {
-            const { x, y } = getCanvasCoordinates(pointerEvent);
-            checkErase(x, y);
-        }
-    });
-
-    if (batch.length > 0) {
-        sendDrawBatch(batch);
-    }
-}
-
-function stopDrawing(event) {
-    if (!isDrawing) return;
-
-    if (typeof event?.pointerId === 'number' && activePointerId !== null && event.pointerId !== activePointerId) {
+    if (!isSupportedPointer(event)) {
         return;
     }
 
-    if (event?.preventDefault) {
-        event.preventDefault();
-    }
+    event.preventDefault();
 
-    if (typeof event?.pointerId === 'number' && typeof canvas.releasePointerCapture === 'function') {
+    if (typeof event.pointerId === 'number' && typeof canvas.releasePointerCapture === 'function') {
         try {
             canvas.releasePointerCapture(event.pointerId);
         } catch (error) {
@@ -730,286 +279,327 @@ function stopDrawing(event) {
         }
     }
 
-    isDrawing = false;
+    addPointToStroke(getCanvasPoint(event));
+    finalizeStroke(false);
+}
 
-    if (drawMode === 'draw' && currentPath) {
-        const batch = [];
+function handlePointerCancel(event) {
+    if (!drawingState.isDrawing) {
+        return;
+    }
 
-        if (currentPath.points.length > 1 && lastStrokeEndpoint && lastStrokePoint) {
-            const finalWidth = computeSegmentWidth(lastStrokePoint.p, lastStrokePoint.p, currentPath.width);
+    if (typeof event.pointerId === 'number' && drawingState.pointerId !== null && event.pointerId !== drawingState.pointerId) {
+        return;
+    }
 
-            ctx.beginPath();
-            ctx.moveTo(lastStrokeEndpoint.x, lastStrokeEndpoint.y);
-            ctx.quadraticCurveTo(lastStrokePoint.x, lastStrokePoint.y, lastStrokePoint.x, lastStrokePoint.y);
-            ctx.lineWidth = finalWidth;
-            ctx.strokeStyle = currentPath.color;
-            ctx.lineCap = 'round';
-            ctx.lineJoin = 'round';
-            ctx.stroke();
+    event.preventDefault();
 
-            batch.push({
-                type: 'quadratic',
-                startX: lastStrokeEndpoint.x,
-                startY: lastStrokeEndpoint.y,
-                controlX: lastStrokePoint.x,
-                controlY: lastStrokePoint.y,
-                endX: lastStrokePoint.x,
-                endY: lastStrokePoint.y,
-                width: finalWidth,
-                color: currentPath.color
-            });
-
-            const radius = Math.max(currentPath.width / 2, finalWidth / 2, currentPath.width * 0.2);
-            ctx.beginPath();
-            ctx.arc(lastStrokePoint.x, lastStrokePoint.y, radius, 0, Math.PI * 2);
-            ctx.fillStyle = currentPath.color;
-            ctx.fill();
-
-            batch.push({
-                type: 'dot',
-                x: lastStrokePoint.x,
-                y: lastStrokePoint.y,
-                radius,
-                color: currentPath.color
-            });
+    if (typeof event.pointerId === 'number' && typeof canvas.releasePointerCapture === 'function') {
+        try {
+            canvas.releasePointerCapture(event.pointerId);
+        } catch (error) {
+            console.warn('Failed to release pointer', error);
         }
+    }
 
-        if (batch.length > 0) {
-            sendDrawBatch(batch);
+    finalizeStroke(true);
+}
+
+function addPointToStroke(rawPoint) {
+    const point = {
+        x: rawPoint.x,
+        y: rawPoint.y,
+        p: clamp(typeof rawPoint.p === 'number' && rawPoint.p > 0 ? rawPoint.p : 0.5, 0.05, 1)
+    };
+
+    drawingState.buffer.push(point);
+    drawingState.history.push(point);
+    scheduleDraw();
+}
+
+function finalizeStroke(cancelled) {
+    drawingState.isDrawing = false;
+    drawingState.pointerId = null;
+
+    if (cancelled || drawingState.history.length === 0) {
+        if (drawingState.rafId !== null) {
+            cancelAnimationFrame(drawingState.rafId);
+            drawingState.rafId = null;
         }
+        drawingState.buffer = [];
+        drawingState.history = [];
+        return;
+    }
 
-        paths.push(currentPath);
-        currentPath = null;
-        pushHistory();
+    if (drawingState.rafId !== null) {
+        cancelAnimationFrame(drawingState.rafId);
+        drawingState.rafId = null;
+    }
+    drawSmoothStroke(true);
+
+    if (drawingState.history.length === 1) {
+        drawDot(ctx, drawingState.history[0], DEFAULT_STROKE_COLOR, DRAW_BASE_WIDTH);
+    }
+
+    const normalisedPoints = drawingState.history
+        .map((point) => normaliseDisplayPoint(point))
+        .filter(Boolean);
+
+    if (normalisedPoints.length > 0) {
+        storedPaths.push({
+            color: DEFAULT_STROKE_COLOR,
+            width: DRAW_BASE_WIDTH,
+            points: normalisedPoints
+        });
         broadcastCanvas('update');
     }
 
-    smoothStrokePoints = [];
-    lastStrokeEndpoint = null;
-    lastStrokePoint = null;
-    activePointerId = null;
+    drawingState.buffer = [];
+    drawingState.history = [];
 }
 
-function pushHistory() {
-    currentStep += 1;
-    if (currentStep < history.length) {
-        history.length = currentStep;
-    }
-
-    history.push({
-        imageData: canvas.toDataURL(),
-        paths: clonePaths(paths),
-        backgroundImage: backgroundImageData
-    });
-
-    updateButtons();
-}
-
-function restoreFromHistory(historyItem) {
-    if (!historyItem) return;
-
-    backgroundImageData = historyItem.backgroundImage || null;
-    if (backgroundImageData) {
-        backgroundImageElement = new Image();
-        backgroundImageElement.src = backgroundImageData;
-    } else {
-        backgroundImageElement = null;
-    }
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    const img = new Image();
-    img.onload = () => {
-        ctx.drawImage(img, 0, 0);
-    };
-    img.src = historyItem.imageData;
-    paths = clonePaths(historyItem.paths);
-    updateButtons();
-}
-
-function updateButtons() {
-    const canUndo = currentStep > 0;
-    const canRedo = currentStep < history.length - 1;
-
-    actionButtons.undo.forEach((btn) => {
-        if (btn) {
-            btn.disabled = !canUndo;
-        }
-    });
-
-    actionButtons.redo.forEach((btn) => {
-        if (btn) {
-            btn.disabled = !canRedo;
-        }
-    });
-}
-
-function redrawCanvas() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    if (backgroundImageElement) {
-        if (backgroundImageElement.complete) {
-            drawBackgroundImage(backgroundImageElement);
-            renderAllPaths();
-        } else {
-            backgroundImageElement.onload = () => {
-                drawBackgroundImage(backgroundImageElement);
-                renderAllPaths();
-                backgroundImageElement.onload = null;
-            };
-            backgroundImageElement.onerror = () => {
-                renderAllPaths();
-                backgroundImageElement.onload = null;
-                backgroundImageElement.onerror = null;
-            };
-            return;
-        }
-    } else {
-        renderAllPaths();
-    }
-}
-
-function renderAllPaths() {
-    paths.forEach((path) => {
-        renderSmoothPath(ctx, path);
-    });
-}
-
-function renderSmoothPath(context, path) {
-    if (!path || !Array.isArray(path.points) || path.points.length === 0) {
+function scheduleDraw() {
+    if (drawingState.rafId !== null) {
         return;
     }
 
-    const points = normalisePathPoints(path.points);
-    if (points.length === 0) {
+    drawingState.rafId = requestAnimationFrame(() => {
+        drawingState.rafId = null;
+        drawSmoothStroke();
+    });
+}
+
+function drawSmoothStroke(flush = false) {
+    if (!ctx) {
+        drawingState.buffer = [];
         return;
     }
+
+    const points = drawingState.buffer;
+    if (!points || points.length === 0) {
+        drawingState.buffer = [];
+        return;
+    }
+
+    ctx.strokeStyle = DEFAULT_STROKE_COLOR;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
 
     if (points.length === 1) {
-        const [point] = points;
-        const radius = Math.max(path.width / 2, 0.5);
-        context.beginPath();
-        context.arc(point.x, point.y, radius, 0, Math.PI * 2);
-        context.fillStyle = path.color;
-        context.fill();
+        drawDot(ctx, points[0], DEFAULT_STROKE_COLOR, DRAW_BASE_WIDTH);
+        drawingState.buffer = flush ? [] : points.slice(-1);
         return;
     }
 
-    let startPoint = { x: points[0].x, y: points[0].y };
+    ctx.beginPath();
     let previous = points[0];
+    ctx.moveTo(previous.x, previous.y);
 
     for (let i = 1; i < points.length; i += 1) {
         const current = points[i];
         const midpoint = getMidpoint(previous, current);
-        const width = computeSegmentWidth(previous.p, current.p, path.width);
+        const width = DRAW_BASE_WIDTH * (((previous.p + current.p) * 0.5) + 0.05);
 
-        context.beginPath();
-        context.moveTo(startPoint.x, startPoint.y);
-        context.quadraticCurveTo(previous.x, previous.y, midpoint.x, midpoint.y);
-        context.lineWidth = width;
-        context.strokeStyle = path.color;
-        context.lineCap = 'round';
-        context.lineJoin = 'round';
-        context.stroke();
-
-        startPoint = midpoint;
-        previous = current;
-    }
-
-    const lastPoint = points[points.length - 1];
-    const finalWidth = computeSegmentWidth(lastPoint.p, lastPoint.p, path.width);
-    const radius = Math.max(path.width / 2, finalWidth / 2, path.width * 0.2);
-    context.beginPath();
-    context.arc(lastPoint.x, lastPoint.y, radius, 0, Math.PI * 2);
-    context.fillStyle = path.color;
-    context.fill();
-}
-
-function drawSmoothSegments(pointsBuffer, color, baseWidth) {
-    const segments = [];
-
-    if (!Array.isArray(pointsBuffer) || pointsBuffer.length < 2) {
-        return { segments, remainingPoints: pointsBuffer };
-    }
-
-    let startPoint = lastStrokeEndpoint
-        ? { x: lastStrokeEndpoint.x, y: lastStrokeEndpoint.y }
-        : { x: pointsBuffer[0].x, y: pointsBuffer[0].y };
-    let previous = pointsBuffer[0];
-
-    for (let i = 1; i < pointsBuffer.length; i += 1) {
-        const current = pointsBuffer[i];
-        const midpoint = getMidpoint(previous, current);
-        const width = computeSegmentWidth(previous.p, current.p, baseWidth);
-
-        ctx.beginPath();
-        ctx.moveTo(startPoint.x, startPoint.y);
-        ctx.quadraticCurveTo(previous.x, previous.y, midpoint.x, midpoint.y);
         ctx.lineWidth = width;
-        ctx.strokeStyle = color;
-        ctx.lineCap = 'round';
-        ctx.lineJoin = 'round';
+        ctx.quadraticCurveTo(previous.x, previous.y, midpoint.x, midpoint.y);
         ctx.stroke();
 
-        segments.push({
-            type: 'quadratic',
-            startX: startPoint.x,
-            startY: startPoint.y,
-            controlX: previous.x,
-            controlY: previous.y,
-            endX: midpoint.x,
-            endY: midpoint.y,
-            width,
-            color
-        });
-
-        startPoint = midpoint;
         previous = current;
     }
 
-    lastStrokeEndpoint = startPoint;
+    drawingState.buffer = flush ? [] : points.slice(-2);
+}
+
+function clearCanvas({ broadcast = false } = {}) {
+    storedPaths = [];
+    drawingState.buffer = [];
+    drawingState.history = [];
+    if (drawingState.rafId !== null) {
+        cancelAnimationFrame(drawingState.rafId);
+        drawingState.rafId = null;
+    }
+    redrawCanvas();
+
+    if (broadcast) {
+        broadcastCanvas('clear');
+    }
+}
+
+function resizeCanvas() {
+    if (!canvas || !ctx) {
+        return;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+        return;
+    }
+
+    const dpr = Math.max(1, Math.min(MAX_DPR, window.devicePixelRatio || 1));
+    canvasSize.width = rect.width;
+    canvasSize.height = rect.height;
+
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    redrawCanvas();
+}
+
+function redrawCanvas() {
+    if (!ctx) {
+        return;
+    }
+
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvasSize.width, canvasSize.height);
+
+    if (backgroundImageElement && backgroundImageElement.complete) {
+        drawBackgroundImage(backgroundImageElement);
+    }
+
+    storedPaths.forEach((path) => {
+        renderStoredPath(path);
+    });
+}
+
+function drawBackgroundImage(image) {
+    if (!ctx) {
+        return;
+    }
+
+    const displayWidth = canvasSize.width;
+    const displayHeight = canvasSize.height;
+    if (!displayWidth || !displayHeight) {
+        return;
+    }
+
+    const canvasRatio = displayWidth / displayHeight;
+    const imageRatio = image.width / image.height;
+
+    let drawWidth = displayWidth;
+    let drawHeight = displayHeight;
+    let offsetX = 0;
+    let offsetY = 0;
+
+    if (imageRatio > canvasRatio) {
+        drawWidth = imageRatio * displayHeight;
+        offsetX = (displayWidth - drawWidth) / 2;
+    } else {
+        drawHeight = displayWidth / imageRatio;
+        offsetY = (displayHeight - drawHeight) / 2;
+    }
+
+    ctx.save();
+    ctx.globalAlpha = 1;
+    ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
+    ctx.restore();
+}
+
+function renderStoredPath(path) {
+    if (!ctx || !path) {
+        return;
+    }
+
+    const points = normaliseStoredPoints(path.points);
+    if (points.length === 0) {
+        return;
+    }
+
+    const color = path.color || DEFAULT_STROKE_COLOR;
+    const baseWidth = typeof path.width === 'number' && path.width > 0 ? path.width : DRAW_BASE_WIDTH;
+
+    if (points.length === 1) {
+        drawDot(ctx, points[0], color, baseWidth);
+        return;
+    }
+
+    ctx.strokeStyle = color;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    ctx.beginPath();
+    let previous = points[0];
+    ctx.moveTo(previous.x, previous.y);
+
+    for (let i = 1; i < points.length; i += 1) {
+        const current = points[i];
+        const midpoint = getMidpoint(previous, current);
+        const width = baseWidth * (((previous.p + current.p) * 0.5) + 0.05);
+
+        ctx.lineWidth = width;
+        ctx.quadraticCurveTo(previous.x, previous.y, midpoint.x, midpoint.y);
+        ctx.stroke();
+
+        previous = current;
+    }
+
+    drawDot(ctx, points[points.length - 1], color, baseWidth);
+}
+
+function applyBackgroundImage(imageData) {
+    backgroundImageData = imageData;
+    const image = new Image();
+    backgroundImageElement = image;
+
+    image.onload = () => {
+        if (backgroundImageElement === image) {
+            redrawCanvas();
+        }
+    };
+
+    image.onerror = () => {
+        if (backgroundImageElement === image) {
+            backgroundImageData = null;
+            backgroundImageElement = null;
+            redrawCanvas();
+        }
+    };
+
+    image.src = imageData;
+}
+
+function removeBackgroundImage() {
+    if (!backgroundImageData && !backgroundImageElement) {
+        return;
+    }
+
+    backgroundImageData = null;
+    backgroundImageElement = null;
+    redrawCanvas();
+}
+
+function handleNextQuestionFromTeacher() {
+    clearCanvas({ broadcast: false });
+    removeBackgroundImage();
+    broadcastCanvas('clear');
+    setStatusBadge('Teacher started the next question', 'pending');
+}
+
+function getCanvasPoint(event) {
+    const rect = canvas.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
 
     return {
-        segments,
-        remainingPoints: pointsBuffer.slice(-1)
+        x,
+        y,
+        p: typeof event.pressure === 'number' && event.pressure > 0 ? event.pressure : 0.5
     };
 }
 
-function normalisePathPoints(rawPoints) {
-    return rawPoints.reduce((accumulator, point) => {
-        if (!point) {
-            return accumulator;
-        }
+function drawDot(context, point, color, baseWidth) {
+    if (!point) {
+        return;
+    }
 
-        if (Array.isArray(point)) {
-            const [x, y, pressure] = point;
-            if (typeof x === 'number' && typeof y === 'number') {
-                accumulator.push({
-                    x,
-                    y,
-                    p: typeof pressure === 'number' ? clamp(pressure, 0.05, 1) : 0.5
-                });
-            }
-            return accumulator;
-        }
+    const width = typeof baseWidth === 'number' && baseWidth > 0 ? baseWidth : DRAW_BASE_WIDTH;
+    const radius = clamp(width * (point.p + 0.05), width * 0.45, width * 1.6);
 
-        if (typeof point === 'object') {
-            const { x, y } = point;
-            if (typeof x === 'number' && typeof y === 'number') {
-                const pressure = typeof point.p === 'number'
-                    ? point.p
-                    : (typeof point.pressure === 'number' ? point.pressure : 0.5);
-                accumulator.push({
-                    x,
-                    y,
-                    p: clamp(pressure, 0.05, 1)
-                });
-            }
-        }
-
-        return accumulator;
-    }, []);
+    context.beginPath();
+    context.arc(point.x, point.y, radius, 0, Math.PI * 2);
+    context.fillStyle = color;
+    context.fill();
 }
 
 function getMidpoint(a, b) {
@@ -1019,445 +609,142 @@ function getMidpoint(a, b) {
     };
 }
 
-function computeSegmentWidth(pressureA, pressureB, baseWidth) {
-    const base = typeof baseWidth === 'number' && baseWidth > 0 ? baseWidth : 1.6;
-    const average = ((pressureA || 0.5) + (pressureB || 0.5)) / 2;
-    const minWidth = base * 0.35;
-    const maxWidth = base * 1.6;
-    const width = base * (average + 0.05);
-    return clamp(width, Math.max(0.75, minWidth), Math.max(minWidth, maxWidth));
+function normaliseDisplayPoint(point) {
+    if (!canvasSize.width || !canvasSize.height) {
+        return null;
+    }
+
+    const x = clamp((point.x / canvasSize.width) * BASE_CANVAS_WIDTH, 0, BASE_CANVAS_WIDTH);
+    const y = clamp((point.y / canvasSize.height) * BASE_CANVAS_HEIGHT, 0, BASE_CANVAS_HEIGHT);
+
+    return [x, y, clamp(point.p, 0.05, 1)];
 }
 
-function clamp(value, min, max) {
-    return Math.min(max, Math.max(min, value));
+function normaliseStoredPoints(rawPoints) {
+    if (!Array.isArray(rawPoints)) {
+        return [];
+    }
+
+    return rawPoints.map(denormalisePoint).filter(Boolean);
 }
 
-function createStrokeSample(event) {
-    const { x, y } = getCanvasCoordinates(event);
-    return {
-        x,
-        y,
-        p: getEventPressure(event)
-    };
-}
+function denormalisePoint(raw) {
+    let x;
+    let y;
+    let pressure;
 
-function getEventPressure(event) {
-    if (typeof event?.pressure === 'number' && event.pressure > 0) {
-        return clamp(event.pressure, 0.05, 1);
+    if (Array.isArray(raw)) {
+        [x, y, pressure] = raw;
+    } else if (raw && typeof raw === 'object') {
+        x = raw.x;
+        y = raw.y;
+        pressure = raw.p ?? raw.pressure;
     }
 
-    const touch = (event?.touches && event.touches[0])
-        || (event?.changedTouches && event.changedTouches[0]);
-
-    if (touch && typeof touch.force === 'number' && touch.force > 0) {
-        return clamp(touch.force, 0.05, 1);
+    if (typeof x !== 'number' || typeof y !== 'number') {
+        return null;
     }
 
-    return 0.5;
-}
-
-function getPointCoordinates(point) {
-    if (Array.isArray(point)) {
-        return {
-            x: point[0],
-            y: point[1]
-        };
-    }
-
-    if (point && typeof point === 'object') {
-        const { x, y } = point;
-        return { x, y };
-    }
-
-    return { x: undefined, y: undefined };
-}
-
-function drawBackgroundImage(image) {
-    const canvasRatio = canvas.width / canvas.height;
-    const imageRatio = image.width / image.height;
-
-    let drawWidth = canvas.width;
-    let drawHeight = canvas.height;
-
-    if (imageRatio > canvasRatio) {
-        drawWidth = canvas.width;
-        drawHeight = canvas.width / imageRatio;
-    } else {
-        drawHeight = canvas.height;
-        drawWidth = canvas.height * imageRatio;
-    }
-
-    const offsetX = (canvas.width - drawWidth) / 2;
-    const offsetY = (canvas.height - drawHeight) / 2;
-
-    ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
-}
-
-function applyBackgroundImage(imageData) {
-    if (typeof imageData !== 'string' || imageData.length === 0) {
-        return;
-    }
-
-    if (imageData === backgroundImageData && backgroundImageElement) {
-        broadcastCanvas('background');
-        setStatusBadge('Reference image refreshed by your teacher', 'success');
-        return;
-    }
-
-    const img = new Image();
-    img.onload = () => {
-        backgroundImageData = imageData;
-        backgroundImageElement = img;
-        redrawCanvas();
-        pushHistory();
-        broadcastCanvas('background');
-        setStatusBadge('Your teacher shared a new reference image', 'success');
-    };
-    img.onerror = () => {
-        console.error('Failed to load background image');
-    };
-    img.src = imageData;
-}
-
-function removeBackgroundImage({ broadcast = true, recordHistory = true, notify = true } = {}) {
-    const hadBackground = Boolean(backgroundImageData || backgroundImageElement);
-
-    if (!hadBackground) {
-        if (notify) {
-            setStatusBadge('Background cleared', 'pending');
-        }
-        if (broadcast) {
-            broadcastCanvas('background');
-        }
-        return;
-    }
-
-    backgroundImageData = null;
-    backgroundImageElement = null;
-    redrawCanvas();
-
-    if (recordHistory) {
-        pushHistory();
-    }
-
-    if (broadcast) {
-        broadcastCanvas('background');
-    }
-
-    if (notify) {
-        setStatusBadge('Reference image removed by your teacher', 'pending');
-    }
-}
-
-function handleNextQuestionFromTeacher() {
-    isDrawing = false;
-    currentPath = null;
-    paths = [];
-    history = [];
-    currentStep = -1;
-    removeBackgroundImage({ broadcast: false, recordHistory: false, notify: false });
-    redrawCanvas();
-    initialiseHistory();
-    broadcastCanvas('clear');
-    setStatusBadge('Teacher started the next question', 'pending');
-}
-
-function checkErase(x, y) {
-    const eraseRadius = currentWidth;
-    let erased = false;
-
-    for (let i = paths.length - 1; i >= 0; i -= 1) {
-        const path = paths[i];
-        if (!path || !Array.isArray(path.points) || path.points.length === 0) {
-            continue;
-        }
-
-        if (path.points.length === 1) {
-            const { x: pointX, y: pointY } = getPointCoordinates(path.points[0]);
-            if (typeof pointX === 'number' && typeof pointY === 'number'
-                && distToSegment(x, y, pointX, pointY, pointX, pointY) <= eraseRadius) {
-                paths.splice(i, 1);
-                erased = true;
-            }
-            continue;
-        }
-
-        for (let j = 1; j < path.points.length; j += 1) {
-            const { x: x1, y: y1 } = getPointCoordinates(path.points[j - 1]);
-            const { x: x2, y: y2 } = getPointCoordinates(path.points[j]);
-
-            if (typeof x1 !== 'number' || typeof y1 !== 'number' || typeof x2 !== 'number' || typeof y2 !== 'number') {
-                continue;
-            }
-
-            if (distToSegment(x, y, x1, y1, x2, y2) <= eraseRadius) {
-                paths.splice(i, 1);
-                erased = true;
-                break;
-            }
-        }
-    }
-
-    if (erased) {
-        redrawCanvas();
-        pushHistory();
-        broadcastCanvas('erase');
-    }
-
-    return erased;
-}
-
-function distToSegment(x, y, x1, y1, x2, y2) {
-    const A = x - x1;
-    const B = y - y1;
-    const C = x2 - x1;
-    const D = y2 - y1;
-
-    const dot = A * C + B * D;
-    const lenSq = C * C + D * D;
-    let param = -1;
-
-    if (lenSq !== 0) {
-        param = dot / lenSq;
-    }
-
-    let xx;
-    let yy;
-
-    if (param < 0) {
-        xx = x1;
-        yy = y1;
-    } else if (param > 1) {
-        xx = x2;
-        yy = y2;
-    } else {
-        xx = x1 + param * C;
-        yy = y1 + param * D;
-    }
-
-    const dx = x - xx;
-    const dy = y - yy;
-
-    return Math.sqrt(dx * dx + dy * dy);
-}
-
-function getCanvasCoordinates(event) {
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = BASE_CANVAS_WIDTH / rect.width;
-    const scaleY = BASE_CANVAS_HEIGHT / rect.height;
-
-    if (event.type.includes('touch')) {
-        const touch = event.touches[0] || event.changedTouches[0];
-        return {
-            x: (touch.clientX - rect.left) * scaleX,
-            y: (touch.clientY - rect.top) * scaleY
-        };
-    }
+    const displayX = (x / BASE_CANVAS_WIDTH) * canvasSize.width;
+    const displayY = (y / BASE_CANVAS_HEIGHT) * canvasSize.height;
 
     return {
-        x: (event.clientX - rect.left) * scaleX,
-        y: (event.clientY - rect.top) * scaleY
+        x: displayX,
+        y: displayY,
+        p: clamp(typeof pressure === 'number' ? pressure : 0.5, 0.05, 1)
     };
-}
-
-function shouldIgnoreEvent(event) {
-    if (!stylusMode || !event) {
-        return false;
-    }
-
-    const hasMultipleTouches = Array.isArray(event.touches) && event.touches.length > 1;
-
-    if (typeof event.pointerType === 'string' && event.pointerType !== '') {
-        const pointerType = event.pointerType.toLowerCase();
-
-        if (pointerType === 'pen' || pointerType === 'mouse') {
-            return false;
-        }
-
-        if (pointerType === 'touch') {
-            if (hasMultipleTouches || event.isPrimary === false) {
-                return true;
-            }
-
-            const width = typeof event.width === 'number' ? event.width : null;
-            const height = typeof event.height === 'number' ? event.height : null;
-            const hasZeroContact = (width !== null && width === 0) || (height !== null && height === 0);
-            const averageWidth = width !== null && height !== null
-                ? (width + height) / 2
-                : (width !== null ? width : height);
-
-            if (averageWidth !== null && averageWidth > 24) {
-                return true;
-            }
-
-            if (hasZeroContact) {
-                return false;
-            }
-
-            if (typeof event.pressure === 'number' && event.pressure > 0) {
-                return false;
-            }
-
-            if (averageWidth !== null && averageWidth <= 18) {
-                return false;
-            }
-
-            if (averageWidth === null) {
-                return false;
-            }
-
-            return true;
-        }
-
-        return true;
-    }
-
-    if (event.type && event.type.includes('touch')) {
-        if (hasMultipleTouches) {
-            return true;
-        }
-
-        const touch = event.touches?.[0] || event.changedTouches?.[0];
-        if (!touch) {
-            return true;
-        }
-
-        if (typeof touch.touchType === 'string') {
-            return touch.touchType !== 'stylus';
-        }
-
-        if (typeof touch.altitudeAngle === 'number' || typeof touch.azimuthAngle === 'number') {
-            return false;
-        }
-
-        const radiusX = typeof touch.radiusX === 'number' ? touch.radiusX : null;
-        const radiusY = typeof touch.radiusY === 'number' ? touch.radiusY : null;
-        const averageRadius = radiusX !== null && radiusY !== null
-            ? (radiusX + radiusY) / 2
-            : (radiusX !== null ? radiusX : radiusY);
-
-        if (averageRadius !== null && averageRadius > 24) {
-            return true;
-        }
-
-        if (typeof touch.force === 'number' && touch.force > 0) {
-            return false;
-        }
-
-        if (averageRadius !== null && averageRadius <= 18) {
-            return false;
-        }
-
-        return true;
-    }
-
-    return false;
-}
-
-function lockViewportZoomForIOS() {
-    if (viewportZoomLocked) {
-        return;
-    }
-
-    const userAgent = navigator.userAgent || '';
-    const isIOS = /iPad|iPhone|iPod/.test(userAgent)
-        || (userAgent.includes('Mac') && 'ontouchend' in document);
-
-    if (!isIOS) {
-        return;
-    }
-
-    const blockMultiTouch = (event) => {
-        if (event.touches && event.touches.length > 1) {
-            event.preventDefault();
-        }
-    };
-
-    const blockGesture = (event) => {
-        event.preventDefault();
-    };
-
-    let lastTouchEnd = 0;
-    const blockDoubleTap = (event) => {
-        const now = Date.now();
-        if (now - lastTouchEnd <= 350) {
-            event.preventDefault();
-        }
-        lastTouchEnd = now;
-    };
-
-    document.addEventListener('gesturestart', blockGesture, { passive: false });
-    document.addEventListener('gesturechange', blockGesture, { passive: false });
-    document.addEventListener('gestureend', blockGesture, { passive: false });
-    document.addEventListener('touchstart', blockMultiTouch, { passive: false });
-    document.addEventListener('touchmove', blockMultiTouch, { passive: false });
-    document.addEventListener('touchend', blockDoubleTap, { passive: false });
-
-    viewportZoomLocked = true;
 }
 
 function clonePaths(source) {
-    return JSON.parse(JSON.stringify(source));
-}
-
-function preventUnwantedSelection(event) {
-    const target = event.target;
-
-    if (!target) {
-        return;
+    if (!Array.isArray(source)) {
+        return [];
     }
 
-    if (target.closest('input, textarea, [contenteditable="true"], [data-allow-selection]')) {
-        return;
-    }
-
-    if (event?.preventDefault) {
-        event.preventDefault();
-    }
+    return source.map((path) => ({
+        color: path.color,
+        width: path.width,
+        points: Array.isArray(path.points)
+            ? path.points.map((point) => (Array.isArray(point) ? [...point] : { ...point }))
+            : []
+    }));
 }
 
 function broadcastCanvas(reason = 'update') {
-    if (!channelReady) return;
-    const snapshot = clonePaths(paths);
+    if (!channelReady) {
+        return;
+    }
+
     const payload = {
         username,
         reason,
         canvasState: {
-            paths: snapshot,
+            paths: clonePaths(storedPaths),
             backgroundImage: backgroundImageData
         }
     };
 
     safeSend('student_canvas', payload);
 
-    if (['clear', 'undo', 'redo', 'erase'].includes(reason)) {
-        safeSend(reason, payload);
+    if (reason === 'clear') {
+        safeSend('clear', payload);
     }
 }
 
-function sendDrawBatch(batch) {
-    safeSend('draw_batch', {
-        username,
-        batch
-    });
-}
-
 function safeSend(event, payload = {}) {
-    if (!channelReady || !channel) return;
+    if (!channelReady || !channel) {
+        return;
+    }
+
     channel.send({ type: 'broadcast', event, payload }).catch((error) => {
         console.error(`Supabase event "${event}" failed`, error);
     });
 }
 
 function setStatusBadge(text, variant) {
-    sessionBadge.textContent = text;
-    sessionBadge.classList.remove('status-badge--error', 'status-badge--pending', 'status-badge--success');
+    if (connectionLabel) {
+        connectionLabel.textContent = text;
+    }
 
-    if (variant === 'error') {
-        sessionBadge.classList.add('status-badge--error');
-    } else if (variant === 'success') {
-        sessionBadge.classList.add('status-badge--success');
-    } else if (variant === 'pending') {
-        sessionBadge.classList.add('status-badge--pending');
+    if (connectionIndicator) {
+        connectionIndicator.classList.remove('status-indicator--success', 'status-indicator--error', 'status-indicator--pending');
+
+        if (variant === 'success') {
+            connectionIndicator.classList.add('status-indicator--success');
+        } else if (variant === 'error') {
+            connectionIndicator.classList.add('status-indicator--error');
+        } else {
+            connectionIndicator.classList.add('status-indicator--pending');
+        }
+    }
+
+    if (statusPill) {
+        statusPill.classList.remove('student-topbar__status--success', 'student-topbar__status--error', 'student-topbar__status--pending');
+
+        if (variant === 'success') {
+            statusPill.classList.add('student-topbar__status--success');
+        } else if (variant === 'error') {
+            statusPill.classList.add('student-topbar__status--error');
+        } else {
+            statusPill.classList.add('student-topbar__status--pending');
+        }
+    }
+}
+
+function isSupportedPointer(event) {
+    if (!event) {
+        return false;
+    }
+
+    const type = typeof event.pointerType === 'string' ? event.pointerType.toLowerCase() : '';
+    return type === '' || type === 'pen' || type === 'mouse';
+}
+
+function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function preventDefault(event) {
+    if (event?.preventDefault) {
+        event.preventDefault();
     }
 }

--- a/public/student.html
+++ b/public/student.html
@@ -1,136 +1,36 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <title>Live Drawing Tool - Student Workspace</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
-    <script type="module" src="js/theme-toggle.js" defer></script>
     <script src="/config.js"></script>
     <script type="module" src="js/student.js" defer></script>
 </head>
-<body class="page page--student">
-    <button id="themeToggle" class="theme-toggle" type="button" aria-label="Switch to dark mode" aria-pressed="false" data-theme="light">
-        <svg class="theme-toggle__icon" viewBox="0 0 24 24" aria-hidden="true">
-            <circle class="theme-toggle__sun-core" cx="12" cy="12" r="4"></circle>
-            <g class="theme-toggle__sun-rays">
-                <line x1="12" y1="2" x2="12" y2="5"></line>
-                <line x1="12" y1="19" x2="12" y2="22"></line>
-                <line x1="4.22" y1="4.22" x2="6.34" y2="6.34"></line>
-                <line x1="17.66" y1="17.66" x2="19.78" y2="19.78"></line>
-                <line x1="2" y1="12" x2="5" y2="12"></line>
-                <line x1="19" y1="12" x2="22" y2="12"></line>
-                <line x1="4.22" y1="19.78" x2="6.34" y2="17.66"></line>
-                <line x1="17.66" y1="6.34" x2="19.78" y2="4.22"></line>
-            </g>
-            <path class="theme-toggle__moon" d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-        </svg>
-    </button>
-    <header class="top-bar top-bar--student">
-        <div class="top-bar__titles">
-            <p class="eyebrow">Student workspace</p>
-            <h1 id="welcomeHeading">Ready to sketch</h1>
-            <p class="subtitle">Your strokes update instantly for the teacher&mdash;relax and focus on drawing.</p>
-        </div>
-        <div class="session-chip">
-            <span class="chip-label">Session</span>
-            <span class="chip-value" id="sessionCodeDisplay">&mdash;&mdash;&mdash;&mdash;</span>
-        </div>
-        <div class="status-badge" id="sessionStatus">Connecting...</div>
-    </header>
-
-    <main class="student-layout">
-        <section class="canvas-panel" id="canvasPanel">
-            <div class="canvas-panel__toolbar">
-                <div class="canvas-panel__titles">
-                    <h2 class="canvas-panel__title">Creative canvas</h2>
-                    <p class="canvas-panel__subtitle">Toggle focus mode for extra drawing space.</p>
-                </div>
+<body class="student-shell">
+    <div class="student-shell__wrap">
+        <header class="student-topbar">
+            <div class="student-topbar__left">
+                <span class="student-topbar__title" id="welcomeHeading">Student canvas</span>
+                <button id="clearCanvasButton" class="student-topbar__button" type="button">Clear</button>
             </div>
-            <div class="canvas-panel__layout">
-                <nav id="canvasToolbar" class="canvas-toolbar" aria-label="Canvas controls">
-                    <div class="canvas-toolbar__group canvas-toolbar__group--history" role="group" aria-label="History">
-                        <button class="quick-action-btn" type="button" data-action="undo" aria-label="Undo" title="Undo">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="9 15 3 9 9 3"></polyline>
-                                <path d="M3 9h10a5 5 0 0 1 0 10h-3"></path>
-                            </svg>
-                        </button>
-                        <button class="quick-action-btn" type="button" data-action="redo" aria-label="Redo" title="Redo">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="15 3 21 9 15 15"></polyline>
-                                <path d="M21 9H11a5 5 0 0 0 0 10h3"></path>
-                            </svg>
-                        </button>
-                        <button class="quick-action-btn quick-action-btn--danger" type="button" data-action="clear" aria-label="Clear canvas" title="Clear canvas">
-                            <svg class="quick-action-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3 6h18"></path>
-                                <path d="M8 6v14a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V6"></path>
-                                <path d="M10 6l1-3h2l1 3"></path>
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="canvas-toolbar__group canvas-toolbar__group--colors" role="group" aria-label="Colors">
-                        <button class="color-btn black" data-color="#1e1b4b" aria-label="Black"></button>
-                        <button class="color-btn blue" data-color="#2563eb" aria-label="Blue"></button>
-                        <button class="color-btn red" data-color="#f43f5e" aria-label="Red"></button>
-                        <button class="color-btn green" data-color="#10b981" aria-label="Green"></button>
-                    </div>
-                    <div class="canvas-toolbar__group canvas-toolbar__group--tools" role="group" aria-label="Drawing mode">
-                        <button class="tool-btn" type="button" data-tool="draw" aria-pressed="false">
-                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3 17.25V21h3.75L19.81 7.94a1.06 1.06 0 0 0 0-1.5l-2.25-2.25a1.06 1.06 0 0 0-1.5 0L3 17.25z" fill="currentColor"></path>
-                                <path d="M14.75 6.04l3.21 3.21"></path>
-                            </svg>
-                            <span class="tool-btn__label">Brush</span>
-                        </button>
-                        <button class="tool-btn" type="button" data-tool="erase" aria-pressed="false">
-                            <svg class="tool-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M3.5 16.5 13.5 6.5a2 2 0 0 1 2.83 0l4.17 4.17a2 2 0 0 1 0 2.83l-6.5 6.5H3.5z" fill="currentColor"></path>
-                                <path d="M6 19.5h7"></path>
-                            </svg>
-                            <span class="tool-btn__label">Eraser</span>
-                        </button>
-                    </div>
-                    <div class="canvas-toolbar__group canvas-toolbar__group--brush" role="group" aria-label="Brush size" hidden aria-hidden="true">
-                        <label class="slider-field slider-field--inline">
-                            <span class="chip-label">Brush size</span>
-                            <input type="range" data-brush-size min="1" max="20" value="5">
-                        </label>
-                    </div>
-                    <div class="canvas-toolbar__group canvas-toolbar__group--stylus" role="group" aria-label="Stylus mode">
-                        <button class="toggle-btn toggle-btn--compact" type="button" data-stylus-toggle aria-pressed="true">
-                            <span class="toggle-btn__label">Stylus</span>
-                            <span class="toggle-btn__status" data-stylus-status>On</span>
-                        </button>
-                    </div>
-                    <div class="canvas-toolbar__spacer" aria-hidden="true"></div>
-                    <div class="canvas-toolbar__group canvas-toolbar__group--fullscreen" role="group" aria-label="Canvas layout">
-                        <button id="fullscreenToggle" class="canvas-panel__action-btn canvas-panel__action-btn--vertical" type="button" aria-pressed="false" aria-label="Enter fullscreen" title="Enter fullscreen">
-                            <svg id="fullscreenEnterIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <polyline points="5 9 5 5 9 5"></polyline>
-                                <polyline points="19 15 19 19 15 19"></polyline>
-                                <polyline points="15 5 19 5 19 9"></polyline>
-                                <polyline points="9 19 5 19 5 15"></polyline>
-                            </svg>
-                            <svg id="fullscreenExitIcon" class="canvas-panel__action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" hidden>
-                                <polyline points="9 5 5 5 5 9"></polyline>
-                                <polyline points="15 19 19 19 19 15"></polyline>
-                                <polyline points="19 9 19 5 15 5"></polyline>
-                                <polyline points="5 15 5 19 9 19"></polyline>
-                            </svg>
-                            <span id="fullscreenToggleLabel" class="visually-hidden">Enter fullscreen</span>
-                        </button>
-                    </div>
-                </nav>
-                <div class="canvas-wrapper" id="canvasWrapper">
-                    <canvas id="drawingCanvas"></canvas>
-                </div>
+            <div class="student-topbar__right">
+                <span class="student-topbar__session">Session <strong id="sessionCodeDisplay">&mdash;&mdash;&mdash;&mdash;</strong></span>
+                <span class="student-topbar__status student-topbar__status--pending" id="connectionStatus" role="status" aria-live="polite">
+                    <span class="status-indicator status-indicator--pending" id="connectionIndicator" aria-hidden="true"></span>
+                    <span id="connectionLabel">Connecting...</span>
+                </span>
             </div>
-        </section>
-    </main>
+        </header>
+        <main class="student-canvas" aria-label="Drawing surface">
+            <div class="student-canvas__surface">
+                <canvas id="drawingCanvas" aria-label="Drawing canvas"></canvas>
+            </div>
+        </main>
+    </div>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1469,3 +1469,313 @@ input[type="range"]::-moz-range-thumb {
     }
 }
 
+
+/* Minimal canvas experience */
+.canvas-app {
+    width: min(100%, 1080px);
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 5vw, 3rem) clamp(2rem, 6vw, 3.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    min-height: 100dvh;
+}
+
+.canvas-app__header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: flex-end;
+    justify-content: space-between;
+}
+
+.canvas-app__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.canvas-app__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.canvas-app__titles h1 {
+    font-size: clamp(1.75rem, 4vw, 2.4rem);
+    color: var(--text-strong);
+}
+
+.canvas-app__session {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.canvas-app__button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.85rem 1.8rem;
+    background: var(--primary);
+    color: var(--text-inverse);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    box-shadow: var(--shadow-primary);
+    transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.canvas-app__button:hover {
+    box-shadow: var(--shadow-primary-hover);
+    background: var(--primary-strong);
+}
+
+.canvas-app__button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
+}
+
+.canvas-app__button:active {
+    transform: translateY(1px);
+}
+
+.canvas-app__stage {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+.canvas-app__surface {
+    width: min(100%, 960px);
+    aspect-ratio: 4 / 3;
+    background: var(--surface);
+    border-radius: 24px;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-panel);
+    overflow: hidden;
+    position: relative;
+    touch-action: none;
+}
+
+.canvas-app__surface::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.canvas-app__surface canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+    background: transparent;
+}
+
+.canvas-app__status {
+    display: flex;
+    justify-content: center;
+}
+
+:root[data-theme="dark"] .canvas-app__surface {
+    background: rgba(17, 24, 39, 0.85);
+    border-color: rgba(148, 163, 184, 0.25);
+    box-shadow: 0 28px 50px rgba(2, 6, 23, 0.55);
+}
+
+@media (max-width: 640px) {
+    .canvas-app {
+        padding: clamp(1rem, 6vw, 2rem);
+        gap: 1.5rem;
+    }
+
+    .canvas-app__header {
+        align-items: stretch;
+    }
+
+    .canvas-app__button {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .canvas-app__surface {
+        border-radius: 18px;
+    }
+}
+
+body.student-shell {
+    margin: 0;
+    min-height: 100vh;
+    background: #f4f5fb;
+    color: #111827;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    overscroll-behavior: none;
+}
+
+body.student-shell * {
+    box-sizing: border-box;
+}
+
+.student-shell__wrap {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    height: 100vh;
+    width: 100%;
+    position: fixed;
+    inset: 0;
+}
+
+.student-topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    padding: 12px 20px;
+    background: rgba(255, 255, 255, 0.9);
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.student-topbar__left,
+.student-topbar__right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.student-topbar__title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.student-topbar__button {
+    font: inherit;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    background: #ffffff;
+    color: #111827;
+    cursor: pointer;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.student-topbar__button:active {
+    transform: translateY(1px);
+}
+
+.student-topbar__button:hover {
+    background: #f1f5f9;
+    box-shadow: 0 4px 12px rgba(148, 163, 184, 0.35);
+}
+
+.student-topbar__session {
+    font-size: 0.95rem;
+    color: #1f2937;
+}
+
+.student-topbar__session strong {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.student-topbar__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9rem;
+    color: #1f2937;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.08);
+}
+
+.status-indicator {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #f59e0b;
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.1);
+}
+
+.status-indicator--success {
+    background: #22c55e;
+}
+
+.status-indicator--error {
+    background: #ef4444;
+}
+
+.status-indicator--pending {
+    background: #f59e0b;
+}
+
+.student-canvas {
+    padding: 16px;
+    padding-bottom: calc(16px + env(safe-area-inset-bottom));
+    padding-left: calc(16px + env(safe-area-inset-left));
+    padding-right: calc(16px + env(safe-area-inset-right));
+    height: 100%;
+    display: flex;
+}
+
+.student-canvas__surface {
+    flex: 1;
+    border-radius: 24px;
+    background: #ffffff;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+    overflow: hidden;
+    position: relative;
+}
+
+.student-canvas__surface canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    touch-action: none;
+    background: #ffffff;
+}
+
+@media (max-width: 768px) {
+    .student-topbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    .student-topbar__left,
+    .student-topbar__right {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .student-canvas {
+        padding: 12px;
+    }
+}
+
+.student-topbar__status--success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #166534;
+}
+
+.student-topbar__status--error {
+    background: rgba(239, 68, 68, 0.15);
+    color: #991b1b;
+}
+
+.student-topbar__status--pending {
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+}


### PR DESCRIPTION
## Summary
- replace the student workspace markup with an iPad-inspired header that fixes the clear button, session code, and connection status in place
- add light-mode styling that dedicates nearly the entire viewport to the canvas while keeping the toolbar compact
- rewrite the student drawing controller to use the iPad smoothing approach while preserving Supabase sync, background handling, and status updates

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68d673bf29c88327a9b991f6e1a6ec2a