### PR TITLE
Add student drawing toolbar controls

### DIFF
--- a/public/js/teacher.js
+++ b/public/js/teacher.js
@@ -608,13 +608,21 @@ function drawSmoothStudentPath(ctx, path) {
         return;
     }
 
+    const baseWidth = typeof path.width === 'number' && path.width > 0 ? path.width : 2.2;
+    const erase = Boolean(path.erase);
+    const strokeColor = erase ? '#000000' : (typeof path.color === 'string' ? path.color : '#111827');
+
+    ctx.save();
+    ctx.globalCompositeOperation = erase ? 'destination-out' : 'source-over';
+
     if (points.length === 1) {
         const [point] = points;
-        const radius = Math.max(path.width / 2, 0.5);
+        const radius = Math.max(baseWidth * (point.p + 0.05), baseWidth * 0.35, baseWidth / 2, 0.5);
         ctx.beginPath();
         ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
-        ctx.fillStyle = path.color;
+        ctx.fillStyle = strokeColor;
         ctx.fill();
+        ctx.restore();
         return;
     }
 
@@ -624,13 +632,13 @@ function drawSmoothStudentPath(ctx, path) {
     for (let i = 1; i < points.length; i += 1) {
         const current = points[i];
         const midpoint = getStudentMidpoint(previous, current);
-        const width = computeStudentSegmentWidth(previous.p, current.p, path.width);
+        const width = computeStudentSegmentWidth(previous.p, current.p, baseWidth);
 
         ctx.beginPath();
         ctx.moveTo(startPoint.x, startPoint.y);
         ctx.quadraticCurveTo(previous.x, previous.y, midpoint.x, midpoint.y);
         ctx.lineWidth = width;
-        ctx.strokeStyle = path.color;
+        ctx.strokeStyle = strokeColor;
         ctx.lineCap = 'round';
         ctx.lineJoin = 'round';
         ctx.stroke();
@@ -640,12 +648,13 @@ function drawSmoothStudentPath(ctx, path) {
     }
 
     const lastPoint = points[points.length - 1];
-    const finalWidth = computeStudentSegmentWidth(lastPoint.p, lastPoint.p, path.width);
-    const radius = Math.max(path.width / 2, finalWidth / 2, path.width * 0.2);
+    const finalWidth = computeStudentSegmentWidth(lastPoint.p, lastPoint.p, baseWidth);
+    const radius = Math.max(baseWidth / 2, finalWidth / 2, baseWidth * 0.35);
     ctx.beginPath();
     ctx.arc(lastPoint.x, lastPoint.y, radius, 0, Math.PI * 2);
-    ctx.fillStyle = path.color;
+    ctx.fillStyle = strokeColor;
     ctx.fill();
+    ctx.restore();
 }
 
 function normaliseStudentPoints(rawPoints) {

--- a/public/student.html
+++ b/public/student.html
@@ -14,16 +14,37 @@
 <body class="student-shell">
     <div class="student-shell__wrap">
         <header class="student-topbar">
-            <div class="student-topbar__left">
-                <span class="student-topbar__title" id="welcomeHeading">Student canvas</span>
-                <button id="clearCanvasButton" class="student-topbar__button" type="button">Clear</button>
+            <div class="student-topbar__row">
+                <div class="student-topbar__left">
+                    <span class="student-topbar__title" id="welcomeHeading">Student canvas</span>
+                </div>
+                <div class="student-topbar__right">
+                    <span class="student-topbar__session">Session <strong id="sessionCodeDisplay">&mdash;&mdash;&mdash;&mdash;</strong></span>
+                    <span class="student-topbar__status student-topbar__status--pending" id="connectionStatus" role="status" aria-live="polite">
+                        <span class="status-indicator status-indicator--pending" id="connectionIndicator" aria-hidden="true"></span>
+                        <span id="connectionLabel">Connecting...</span>
+                    </span>
+                </div>
             </div>
-            <div class="student-topbar__right">
-                <span class="student-topbar__session">Session <strong id="sessionCodeDisplay">&mdash;&mdash;&mdash;&mdash;</strong></span>
-                <span class="student-topbar__status student-topbar__status--pending" id="connectionStatus" role="status" aria-live="polite">
-                    <span class="status-indicator status-indicator--pending" id="connectionIndicator" aria-hidden="true"></span>
-                    <span id="connectionLabel">Connecting...</span>
-                </span>
+            <div class="student-toolbar" role="toolbar" aria-label="Drawing controls">
+                <div class="student-toolbar__group" role="group" aria-label="Choose colour">
+                    <button class="student-toolbar__button student-toolbar__button--color is-active" type="button" data-color="#111827" style="--swatch-color: #111827" aria-label="Use black ink" data-color-name="Black"></button>
+                    <button class="student-toolbar__button student-toolbar__button--color" type="button" data-color="#ef4444" style="--swatch-color: #ef4444" aria-label="Use red ink" data-color-name="Red"></button>
+                    <button class="student-toolbar__button student-toolbar__button--color" type="button" data-color="#16a34a" style="--swatch-color: #16a34a" aria-label="Use green ink" data-color-name="Green"></button>
+                    <button class="student-toolbar__button student-toolbar__button--color" type="button" data-color="#2563eb" style="--swatch-color: #2563eb" aria-label="Use blue ink" data-color-name="Blue"></button>
+                </div>
+                <div class="student-toolbar__group" role="group" aria-label="Drawing mode">
+                    <button class="student-toolbar__button is-active" type="button" data-tool="brush">Brush</button>
+                    <button class="student-toolbar__button" type="button" data-tool="eraser">Eraser</button>
+                </div>
+                <div class="student-toolbar__group" role="group" aria-label="Canvas actions">
+                    <button id="undoButton" class="student-toolbar__button" type="button" disabled>Undo</button>
+                    <button id="redoButton" class="student-toolbar__button" type="button" disabled>Redo</button>
+                    <button id="clearCanvasButton" class="student-toolbar__button student-toolbar__button--danger" type="button">Clear</button>
+                </div>
+                <div class="student-toolbar__group" role="group" aria-label="Stylus preferences">
+                    <button id="stylusModeButton" class="student-toolbar__button" type="button" aria-pressed="false">Stylus mode</button>
+                </div>
             </div>
         </header>
         <main class="student-canvas" aria-label="Drawing surface">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1611,10 +1611,19 @@ input[type="range"]::-moz-range-thumb {
 body.student-shell {
     margin: 0;
     min-height: 100vh;
+    height: 100vh;
     background: #f4f5fb;
     color: #111827;
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     overscroll-behavior: none;
+    overflow: hidden;
+}
+
+@supports (height: 100dvh) {
+    body.student-shell {
+        min-height: 100dvh;
+        height: 100dvh;
+    }
 }
 
 body.student-shell * {
@@ -1624,25 +1633,40 @@ body.student-shell * {
 .student-shell__wrap {
     display: grid;
     grid-template-rows: auto 1fr;
-    height: 100vh;
     width: 100%;
-    position: fixed;
-    inset: 0;
+    height: var(--student-viewport-height, 100vh);
+    min-height: var(--student-viewport-height, 100vh);
+    overflow: hidden;
 }
+
+@supports (height: 100dvh) {
+    .student-shell__wrap {
+        height: var(--student-viewport-height, 100dvh);
+        min-height: var(--student-viewport-height, 100dvh);
+    }
+}
+
 
 .student-topbar {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-    padding: 12px 20px;
-    background: rgba(255, 255, 255, 0.9);
-    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 20px;
+    background: var(--surface-muted);
+    background: color-mix(in srgb, var(--surface) 85%, transparent);
+    border-bottom: 1px solid var(--border);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     position: sticky;
     top: 0;
     z-index: 10;
+}
+
+.student-topbar__row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
 }
 
 .student-topbar__left,
@@ -1655,33 +1679,12 @@ body.student-shell * {
 .student-topbar__title {
     font-size: 1rem;
     font-weight: 600;
-    color: #1f2937;
-}
-
-.student-topbar__button {
-    font: inherit;
-    font-weight: 500;
-    padding: 8px 16px;
-    border-radius: 999px;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    background: #ffffff;
-    color: #111827;
-    cursor: pointer;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.student-topbar__button:active {
-    transform: translateY(1px);
-}
-
-.student-topbar__button:hover {
-    background: #f1f5f9;
-    box-shadow: 0 4px 12px rgba(148, 163, 184, 0.35);
+    color: var(--text-strong);
 }
 
 .student-topbar__session {
     font-size: 0.95rem;
-    color: #1f2937;
+    color: var(--text-strong);
 }
 
 .student-topbar__session strong {
@@ -1694,7 +1697,7 @@ body.student-shell * {
     align-items: center;
     gap: 8px;
     font-size: 0.9rem;
-    color: #1f2937;
+    color: var(--text-strong);
     padding: 6px 10px;
     border-radius: 999px;
     background: rgba(59, 130, 246, 0.08);
@@ -1728,6 +1731,7 @@ body.student-shell * {
     padding-right: calc(16px + env(safe-area-inset-right));
     height: 100%;
     display: flex;
+    min-height: 0;
 }
 
 .student-canvas__surface {
@@ -1737,6 +1741,8 @@ body.student-shell * {
     box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
     overflow: hidden;
     position: relative;
+    min-height: 0;
+    height: 100%;
 }
 
 .student-canvas__surface canvas {
@@ -1747,17 +1753,137 @@ body.student-shell * {
     background: #ffffff;
 }
 
+.student-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+}
+
+.student-toolbar__group {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: var(--surface-soft);
+    background: color-mix(in srgb, var(--surface-soft) 70%, transparent);
+    border: 1px solid var(--border);
+    border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.student-toolbar__button {
+    font: inherit;
+    font-weight: 500;
+    padding: 6px 14px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--text-strong);
+    cursor: pointer;
+    transition: transform 0.15s ease, background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.student-toolbar__button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-primary);
+}
+
+.student-toolbar__button:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--surface-muted) 70%, transparent);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+}
+
+.student-toolbar__button:active:not(:disabled) {
+    transform: translateY(1px);
+}
+
+.student-toolbar__button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.student-toolbar__button.is-active {
+    background: var(--primary-soft);
+    border-color: var(--primary);
+    box-shadow: var(--shadow-tool-active);
+}
+
+.student-toolbar__button--danger {
+    color: var(--danger);
+}
+
+.student-toolbar__button--color {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border-radius: 999px;
+    border: 2px solid transparent;
+    background: transparent;
+    box-shadow: none;
+}
+
+.student-toolbar__button--color::before {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--swatch-color, #111827);
+    box-shadow: var(--shadow-color-btn);
+}
+
+.student-toolbar__button--color:hover:not(:disabled)::before,
+.student-toolbar__button--color.is-active::before {
+    box-shadow: 0 12px 30px rgba(99, 102, 241, 0.35);
+}
+
+.student-toolbar__button--color.is-active {
+    border-color: var(--primary);
+}
+
+.student-toolbar__button--color:focus-visible {
+    box-shadow: var(--focus-primary);
+}
+
+.student-toolbar__group:last-child {
+    margin-left: auto;
+}
+
 @media (max-width: 768px) {
-    .student-topbar {
+    .student-topbar__row {
         flex-direction: column;
         align-items: flex-start;
-        gap: 12px;
+        gap: 8px;
     }
 
-    .student-topbar__left,
     .student-topbar__right {
         width: 100%;
         justify-content: space-between;
+    }
+
+    .student-toolbar__group {
+        width: 100%;
+        justify-content: space-between;
+        flex-wrap: wrap;
+    }
+
+    .student-toolbar__group:last-child {
+        margin-left: 0;
+    }
+
+    .student-toolbar__button {
+        flex: 1 1 auto;
+        justify-content: center;
+    }
+
+    .student-toolbar__button--color {
+        flex: 0 0 auto;
     }
 
     .student-canvas {


### PR DESCRIPTION
## Summary
- add a student toolbar with color palette, brush/eraser toggle, undo/redo, clear and stylus mode controls
- update drawing logic to support tool selection, erasing, undo/redo history, and stylus-only input filtering
- ensure teacher canvas rendering respects eraser paths when replaying student drawings
- force the student layout and canvas sizing to fit the iPad viewport without requiring scrolling

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d67985c26083278cec1483a64abf2f