### PR TITLE
Enable stylus-first pen mode and stroke eraser

### DIFF
--- a/public/student.html
+++ b/public/student.html
@@ -34,7 +34,7 @@
                     <button class="student-toolbar__button student-toolbar__button--color" type="button" data-color="#2563eb" style="--swatch-color: #2563eb" aria-label="Use blue ink" data-color-name="Blue"></button>
                 </div>
                 <div class="student-toolbar__group" role="group" aria-label="Drawing mode">
-                    <button class="student-toolbar__button is-active" type="button" data-tool="brush">Brush</button>
+                    <button class="student-toolbar__button is-active" type="button" data-tool="pen">Pen</button>
                     <button class="student-toolbar__button" type="button" data-tool="eraser">Eraser</button>
                 </div>
                 <div class="student-toolbar__group" role="group" aria-label="Canvas actions">


### PR DESCRIPTION
## Summary
- default the student canvas to stylus mode and relabel the drawing tool as a pen
- add stroke-aware erasing that removes entire strokes instead of painting transparency
- update undo/redo history tracking so actions respond immediately without no-op clicks

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d685845e808327b94d185a57a115c6