### PR TITLE
Fix stylus mode tooltip syntax

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -314,7 +314,10 @@ function updateStylusModeButton() {
     stylusButton.classList.toggle('is-active', toolState.stylusOnly);
     stylusButton.setAttribute('aria-pressed', toolState.stylusOnly ? 'true' : 'false');
     stylusButton.textContent = toolState.stylusOnly ? 'Stylus mode (pen only)' : 'Stylus mode';
-    stylusButton.setAttribute('title', toolState.stylusOnly ? 'Stylus and mouse input only' : 'Allow pen, touch and mouse input');
+    stylusButton.setAttribute(
+        'title',
+        toolState.stylusOnly ? 'Stylus and mouse input only' : 'Allow pen, touch and mouse input'
+    );
 }
 
 function updateHistoryButtons() {


### PR DESCRIPTION
## Summary
- fix the stylus mode button tooltip setup so the title attribute is applied without causing a syntax error

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d6ce6ffbf0832783c06b3b40dbb46b