### PR TITLE
Add vector overlay syncing for preset backgrounds

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -54,6 +54,7 @@ let historyActions = [];
 let redoActions = [];
 let backgroundImageData = null;
 let backgroundImageElement = null;
+let backgroundVectorDefinition = null;
 
 const reliableState = {
     lastSequence: readNumericSession(RELIABLE_SEQUENCE_STORAGE_KEY, 0),
@@ -569,6 +570,13 @@ function handleTeacherBackgroundEvent(payload = {}) {
 
     if (!trackReliableSequence(payload)) {
         return;
+    }
+
+    const vectorData = payload.vector ?? payload.vectorElements ?? null;
+    if (vectorData) {
+        applyBackgroundVectors(vectorData);
+    } else {
+        clearBackgroundVectors();
     }
 
     const { imageData } = payload;
@@ -1190,6 +1198,10 @@ function redrawCanvas() {
         drawBackgroundImage(backgroundImageElement);
     }
 
+    if (backgroundVectorDefinition) {
+        drawBackgroundVectors(backgroundVectorDefinition);
+    }
+
     storedPaths.forEach((path) => {
         renderStoredPath(path);
     });
@@ -1204,31 +1216,543 @@ function drawBackgroundImage(image) {
 
     const displayWidth = canvasSize.width;
     const displayHeight = canvasSize.height;
-    if (!displayWidth || !displayHeight) {
+    if (!displayWidth || !displayHeight || !image.width || !image.height) {
         return;
     }
 
-    const canvasRatio = displayWidth / displayHeight;
-    const imageRatio = image.width / image.height;
-
-    let drawWidth = displayWidth;
-    let drawHeight = displayHeight;
-    let offsetX = 0;
-    let offsetY = 0;
-
-    if (imageRatio > canvasRatio) {
-        drawWidth = imageRatio * displayHeight;
-        offsetX = (displayWidth - drawWidth) / 2;
-    } else {
-        drawHeight = displayHeight;
-        drawWidth = displayHeight * imageRatio;
-        offsetX = (displayWidth - drawWidth) / 2;
-    }
+    const { drawWidth, drawHeight, offsetX, offsetY } = calculateContainDimensions(
+        image.width,
+        image.height,
+        displayWidth,
+        displayHeight
+    );
 
     ctx.save();
     ctx.globalAlpha = 1;
     ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
     ctx.restore();
+}
+
+function applyBackgroundVectors(definition) {
+    const normalised = normaliseBackgroundVectorDefinition(definition);
+    if (!normalised) {
+        if (backgroundVectorDefinition) {
+            backgroundVectorDefinition = null;
+            redrawCanvas();
+        }
+        return;
+    }
+
+    if (vectorDefinitionsEqual(backgroundVectorDefinition, normalised)) {
+        return;
+    }
+
+    backgroundVectorDefinition = normalised;
+    redrawCanvas();
+}
+
+function clearBackgroundVectors() {
+    if (!backgroundVectorDefinition) {
+        return;
+    }
+
+    backgroundVectorDefinition = null;
+    redrawCanvas();
+}
+
+function drawBackgroundVectors(definition) {
+    if (!ctx) {
+        return;
+    }
+
+    if (!canvasSize.width || !canvasSize.height) {
+        return;
+    }
+
+    const normalised = normaliseBackgroundVectorDefinition(definition);
+    if (!normalised) {
+        return;
+    }
+
+    const { width, height, elements } = normalised;
+    if (!width || !height || elements.length === 0) {
+        return;
+    }
+
+    const { drawWidth, drawHeight, offsetX, offsetY } = calculateContainDimensions(
+        width,
+        height,
+        canvasSize.width,
+        canvasSize.height
+    );
+
+    const scaleX = drawWidth / width;
+    const scaleY = drawHeight / height;
+
+    ctx.save();
+    ctx.translate(offsetX, offsetY);
+    ctx.scale(scaleX, scaleY);
+
+    elements.forEach((element) => {
+        ctx.save();
+
+        const opacity = typeof element.opacity === 'number'
+            ? clamp(element.opacity, 0, 1)
+            : 1;
+        ctx.globalAlpha = opacity;
+
+        if (Array.isArray(element.dash) && element.dash.length > 0) {
+            ctx.setLineDash(element.dash);
+        } else {
+            ctx.setLineDash([]);
+        }
+
+        switch (element.type) {
+            case 'line':
+                ctx.beginPath();
+                ctx.lineCap = element.cap || 'butt';
+                ctx.lineJoin = element.join || 'miter';
+                ctx.lineWidth = element.strokeWidth || 1;
+                ctx.strokeStyle = element.stroke || '#000000';
+                ctx.moveTo(element.x1, element.y1);
+                ctx.lineTo(element.x2, element.y2);
+                ctx.stroke();
+                break;
+            case 'arrow':
+                ctx.beginPath();
+                ctx.lineCap = element.cap || 'butt';
+                ctx.lineJoin = element.join || 'miter';
+                ctx.lineWidth = element.strokeWidth || 1;
+                ctx.strokeStyle = element.stroke || '#000000';
+                ctx.moveTo(element.x1, element.y1);
+                ctx.lineTo(element.x2, element.y2);
+                ctx.stroke();
+                drawVectorArrowHead(ctx, element);
+                break;
+            case 'rect':
+            case 'roundedRect': {
+                drawVectorRoundedRect(ctx, element.x, element.y, element.width, element.height, element.radius || 0);
+                if (element.fill) {
+                    ctx.fillStyle = element.fill;
+                    ctx.fill();
+                }
+                if (element.stroke && element.strokeWidth > 0) {
+                    ctx.strokeStyle = element.stroke;
+                    ctx.lineWidth = element.strokeWidth;
+                    ctx.lineJoin = element.join || 'miter';
+                    ctx.stroke();
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        ctx.restore();
+    });
+
+    ctx.restore();
+}
+
+function drawVectorRoundedRect(ctx, x, y, width, height, radius) {
+    const resolvedRadius = Math.max(0, Math.min(radius || 0, Math.min(width, height) / 2));
+
+    ctx.beginPath();
+    if (resolvedRadius === 0) {
+        ctx.rect(x, y, width, height);
+        return;
+    }
+
+    ctx.moveTo(x + resolvedRadius, y);
+    ctx.lineTo(x + width - resolvedRadius, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + resolvedRadius);
+    ctx.lineTo(x + width, y + height - resolvedRadius);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - resolvedRadius, y + height);
+    ctx.lineTo(x + resolvedRadius, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - resolvedRadius);
+    ctx.lineTo(x, y + resolvedRadius);
+    ctx.quadraticCurveTo(x, y, x + resolvedRadius, y);
+    ctx.closePath();
+}
+
+function drawVectorArrowHead(ctx, element) {
+    const headLength = element.headLength || Math.max(12, (element.strokeWidth || 1) * 3);
+    const headWidth = element.headWidth || headLength * 0.6;
+    const angle = Math.atan2(element.y2 - element.y1, element.x2 - element.x1);
+
+    const sin = Math.sin(angle);
+    const cos = Math.cos(angle);
+
+    const leftX = element.x2 - headLength * cos + (headWidth / 2) * sin;
+    const leftY = element.y2 - headLength * sin - (headWidth / 2) * cos;
+    const rightX = element.x2 - headLength * cos - (headWidth / 2) * sin;
+    const rightY = element.y2 - headLength * sin + (headWidth / 2) * cos;
+
+    ctx.beginPath();
+    ctx.moveTo(element.x2, element.y2);
+    ctx.lineTo(leftX, leftY);
+    ctx.lineTo(rightX, rightY);
+    ctx.closePath();
+    ctx.fillStyle = element.fill || element.stroke || '#000000';
+    ctx.fill();
+}
+
+function calculateContainDimensions(sourceWidth, sourceHeight, targetWidth, targetHeight) {
+    if (!sourceWidth || !sourceHeight) {
+        return { drawWidth: 0, drawHeight: 0, offsetX: 0, offsetY: 0 };
+    }
+
+    const sourceRatio = sourceWidth / sourceHeight;
+    const targetRatio = targetWidth / targetHeight;
+
+    let drawWidth = targetWidth;
+    let drawHeight = targetHeight;
+
+    if (sourceRatio > targetRatio) {
+        drawHeight = targetWidth / sourceRatio;
+    } else {
+        drawWidth = targetHeight * sourceRatio;
+    }
+
+    const offsetX = (targetWidth - drawWidth) / 2;
+    const offsetY = (targetHeight - drawHeight) / 2;
+
+    return { drawWidth, drawHeight, offsetX, offsetY };
+}
+
+function cloneBackgroundVectorDefinition(definition) {
+    const normalised = normaliseBackgroundVectorDefinition(definition);
+    if (!normalised) {
+        return null;
+    }
+
+    return {
+        width: normalised.width,
+        height: normalised.height,
+        elements: normalised.elements.map((element) => ({
+            ...element,
+            dash: Array.isArray(element.dash) ? [...element.dash] : undefined
+        }))
+    };
+}
+
+function normaliseBackgroundVectorDefinition(definition) {
+    if (!definition || typeof definition !== 'object') {
+        return null;
+    }
+
+    const width = toPositiveNumber(
+        definition.width ?? definition.viewBoxWidth ?? (definition.viewBox && definition.viewBox.width)
+    );
+    const height = toPositiveNumber(
+        definition.height ?? definition.viewBoxHeight ?? (definition.viewBox && definition.viewBox.height)
+    );
+
+    if (!width || !height) {
+        return null;
+    }
+
+    const sourceElements = Array.isArray(definition.elements) ? definition.elements : [];
+    const elements = sourceElements.reduce((accumulator, element) => {
+        const normalisedElement = normaliseVectorElement(element);
+        if (normalisedElement) {
+            accumulator.push(normalisedElement);
+        }
+        return accumulator;
+    }, []);
+
+    if (elements.length === 0) {
+        return null;
+    }
+
+    return { width, height, elements };
+}
+
+function normaliseVectorElement(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+
+    const type = typeof element.type === 'string' ? element.type : '';
+
+    if (type === 'line' || type === 'arrow') {
+        const x1 = toFiniteNumber(element.x1);
+        const y1 = toFiniteNumber(element.y1);
+        const x2 = toFiniteNumber(element.x2);
+        const y2 = toFiniteNumber(element.y2);
+
+        if (x1 === null || y1 === null || x2 === null || y2 === null) {
+            return null;
+        }
+
+        const strokeWidth = toPositiveNumber(element.strokeWidth, 1);
+        const stroke = normaliseColor(element.stroke) || '#000000';
+
+        const base = {
+            type,
+            x1,
+            y1,
+            x2,
+            y2,
+            stroke,
+            strokeWidth,
+            cap: normaliseLineCap(element.cap),
+            join: normaliseLineJoin(element.join),
+            dash: normaliseDashArray(element.dash),
+            opacity: normaliseOpacity(element.opacity)
+        };
+
+        if (type === 'arrow') {
+            return {
+                ...base,
+                headLength: toPositiveNumber(element.headLength, Math.max(12, strokeWidth * 3)),
+                headWidth: toPositiveNumber(element.headWidth, Math.max(8, strokeWidth * 2)),
+                fill: normaliseColor(element.fill) || stroke
+            };
+        }
+
+        return base;
+    }
+
+    if (type === 'rect' || type === 'roundedRect') {
+        const x = toFiniteNumber(element.x);
+        const y = toFiniteNumber(element.y);
+        const width = toPositiveNumber(element.width);
+        const height = toPositiveNumber(element.height);
+
+        if (x === null || y === null || !width || !height) {
+            return null;
+        }
+
+        const strokeWidthValue = toPositiveNumber(element.strokeWidth, null);
+
+        return {
+            type,
+            x,
+            y,
+            width,
+            height,
+            radius: type === 'roundedRect'
+                ? toNonNegativeNumber(element.radius, 0)
+                : 0,
+            stroke: normaliseColor(element.stroke),
+            strokeWidth: strokeWidthValue ?? 0,
+            fill: normaliseFill(element.fill),
+            join: normaliseLineJoin(element.join),
+            opacity: normaliseOpacity(element.opacity)
+        };
+    }
+
+    return null;
+}
+
+function normaliseLineCap(value) {
+    if (typeof value !== 'string') {
+        return 'butt';
+    }
+
+    const cap = value.toLowerCase();
+    return cap === 'round' || cap === 'square' ? cap : 'butt';
+}
+
+function normaliseLineJoin(value) {
+    if (typeof value !== 'string') {
+        return 'miter';
+    }
+
+    const join = value.toLowerCase();
+    return join === 'round' || join === 'bevel' ? join : 'miter';
+}
+
+function normaliseDashArray(value) {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+
+    const dash = value
+        .map((entry) => toPositiveNumber(entry, null))
+        .filter((entry) => entry !== null);
+
+    return dash.length > 0 ? dash : undefined;
+}
+
+function normaliseOpacity(value) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return 1;
+    }
+
+    return clamp(value, 0, 1);
+}
+
+function normaliseColor(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length === 0 || trimmed.toLowerCase() === 'none'
+        ? null
+        : trimmed;
+}
+
+function normaliseFill(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0 || trimmed.toLowerCase() === 'none') {
+        return null;
+    }
+    return trimmed;
+}
+
+function toFiniteNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function toPositiveNumber(value, fallback = null) {
+    const numeric = typeof value === 'number' && Number.isFinite(value) ? value : null;
+    if (numeric === null || numeric <= 0) {
+        return fallback && Number.isFinite(fallback) && fallback > 0 ? fallback : null;
+    }
+    return numeric;
+}
+
+function toNonNegativeNumber(value, fallback = 0) {
+    const numeric = typeof value === 'number' && Number.isFinite(value) ? value : null;
+    if (numeric === null || numeric < 0) {
+        return fallback >= 0 ? fallback : 0;
+    }
+    return numeric;
+}
+
+function vectorDefinitionsEqual(a, b) {
+    if (!a && !b) {
+        return true;
+    }
+
+    if (!a || !b) {
+        return false;
+    }
+
+    if (a.width !== b.width || a.height !== b.height) {
+        return false;
+    }
+
+    const elementsA = Array.isArray(a.elements) ? a.elements : [];
+    const elementsB = Array.isArray(b.elements) ? b.elements : [];
+
+    if (elementsA.length !== elementsB.length) {
+        return false;
+    }
+
+    for (let i = 0; i < elementsA.length; i += 1) {
+        if (!vectorElementsEqual(elementsA[i], elementsB[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function vectorElementsEqual(a, b) {
+    if (!a || !b || a.type !== b.type) {
+        return false;
+    }
+
+    if (a.type === 'line' || a.type === 'arrow') {
+        if (a.x1 !== b.x1 || a.y1 !== b.y1 || a.x2 !== b.x2 || a.y2 !== b.y2) {
+            return false;
+        }
+
+        if (a.stroke !== b.stroke || a.strokeWidth !== b.strokeWidth) {
+            return false;
+        }
+
+        if ((a.cap || 'butt') !== (b.cap || 'butt')) {
+            return false;
+        }
+
+        if ((a.join || 'miter') !== (b.join || 'miter')) {
+            return false;
+        }
+
+        if (!dashArraysEqual(a.dash, b.dash)) {
+            return false;
+        }
+
+        if ((a.opacity ?? 1) !== (b.opacity ?? 1)) {
+            return false;
+        }
+
+        if (a.type === 'arrow') {
+            if (a.headLength !== b.headLength || a.headWidth !== b.headWidth) {
+                return false;
+            }
+            if ((a.fill || null) !== (b.fill || null)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (a.type === 'rect' || a.type === 'roundedRect') {
+        if (a.x !== b.x || a.y !== b.y || a.width !== b.width || a.height !== b.height) {
+            return false;
+        }
+
+        if ((a.radius || 0) !== (b.radius || 0)) {
+            return false;
+        }
+
+        if ((a.stroke || null) !== (b.stroke || null)) {
+            return false;
+        }
+
+        if ((a.strokeWidth || 0) !== (b.strokeWidth || 0)) {
+            return false;
+        }
+
+        if ((a.fill || null) !== (b.fill || null)) {
+            return false;
+        }
+
+        if ((a.join || 'miter') !== (b.join || 'miter')) {
+            return false;
+        }
+
+        if ((a.opacity ?? 1) !== (b.opacity ?? 1)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+function dashArraysEqual(a, b) {
+    if (!Array.isArray(a) && !Array.isArray(b)) {
+        return true;
+    }
+
+    if (!Array.isArray(a) || !Array.isArray(b)) {
+        return false;
+    }
+
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    for (let i = 0; i < a.length; i += 1) {
+        if (a[i] !== b[i]) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 function renderStoredPath(path) {
@@ -1323,6 +1847,7 @@ function handleNextQuestionFromTeacher(nextQuestionNumber = null) {
     }
 
     clearCanvas({ broadcast: false });
+    clearBackgroundVectors();
     removeBackgroundImage();
     broadcastCanvas('clear');
     setStatusBadge('Teacher started the next question', 'pending');
@@ -1469,7 +1994,8 @@ function broadcastCanvas(reason = 'update') {
         reason,
         canvasState: {
             paths: clonePaths(storedPaths),
-            backgroundImage: backgroundImageData
+            backgroundImage: backgroundImageData,
+            backgroundVectors: cloneBackgroundVectorDefinition(backgroundVectorDefinition)
         }
     };
 

--- a/public/js/teacher.js
+++ b/public/js/teacher.js
@@ -36,7 +36,8 @@ const PRESET_BACKGROUNDS = Object.freeze({
                 <line x1="512" y1="80" x2="512" y2="944" stroke="#8fbf68" stroke-width="18" stroke-linecap="round" stroke-dasharray="2 26" stroke-opacity="0.9"/>
             </svg>
         `),
-        previewAlt: 'Chinese words practice grid preview'
+        previewAlt: 'Chinese words practice grid preview',
+        vector: createChineseVectorData()
     },
     graphCross: {
         id: 'graphCross',
@@ -68,7 +69,8 @@ const PRESET_BACKGROUNDS = Object.freeze({
                 <line x1="512" y1="944" x2="512" y2="80" stroke="#4b5563" stroke-width="8" marker-end="url(#arrow-head)"/>
             </svg>
         `),
-        previewAlt: 'Graph grid with centered axes preview'
+        previewAlt: 'Graph grid with centered axes preview',
+        vector: createGraphCrossVectorData()
     },
     graphCorner: {
         id: 'graphCorner',
@@ -100,7 +102,8 @@ const PRESET_BACKGROUNDS = Object.freeze({
                 <line x1="96" y1="896" x2="912" y2="896" stroke="#334155" stroke-width="10" marker-end="url(#arrow-head-corner)"/>
             </svg>
         `),
-        previewAlt: 'Corner graph grid preview'
+        previewAlt: 'Corner graph grid preview',
+        vector: createGraphCornerVectorData()
     }
 });
 const BASE_CANVAS_WIDTH = 800;
@@ -114,6 +117,7 @@ let syncInterval = null;
 let selectedImageData = null;
 let selectedImageName = '';
 let activeBackgroundImage = null;
+let activeBackgroundVectors = null;
 let preferredGridColumns = 3;
 let activeModalStudent = null;
 let modalReturnFocus = null;
@@ -387,7 +391,7 @@ function sendReliableBroadcast(event, payload = {}, options = {}) {
 }
 
 function recordBackgroundChange(imageData, meta = {}) {
-    sessionState.backgroundActive = Boolean(imageData);
+    sessionState.backgroundActive = Boolean(imageData) || Boolean(activeBackgroundVectors);
     sessionState.backgroundVersion += 1;
     sessionState.backgroundName = imageData
         ? (meta.name || meta.label || null)
@@ -592,6 +596,7 @@ function ensureStudentCard(username) {
         lastActivity: Date.now(),
         backgroundImageData: null,
         backgroundImageElement: null,
+        backgroundVectors: null,
         paths: [],
         previewCanvas: null,
         previewCtx: null
@@ -606,6 +611,7 @@ function updateStudentCanvas(username, canvasState) {
     if (!student || !canvasState) return;
 
     student.paths = Array.isArray(canvasState.paths) ? canvasState.paths : [];
+    student.backgroundVectors = normaliseBackgroundVectorDefinition(canvasState.backgroundVectors);
 
     const markSynced = () => {
         setStudentSyncState(username, true);
@@ -926,10 +932,12 @@ function applyPresetBackground(presetId) {
     }
 
     activeBackgroundImage = preset.imageData;
+    activeBackgroundVectors = cloneBackgroundVectorDefinition(preset.vector);
     recordBackgroundChange(preset.imageData, { name: preset.label, label: preset.label });
     sendReliableBroadcast('set_background', {
         imageData: preset.imageData,
-        presetId: preset.id || null
+        presetId: preset.id || null,
+        vector: cloneBackgroundVectorDefinition(activeBackgroundVectors)
     });
     updateReferenceStatus(`${preset.label} mode sent to your students.`);
     closeModeModal();
@@ -1179,12 +1187,14 @@ function handlePushImageToStudents() {
         return;
     }
 
+    activeBackgroundImage = selectedImageData;
+    activeBackgroundVectors = null;
     recordBackgroundChange(selectedImageData, { name: selectedImageName || 'Uploaded image' });
     sendReliableBroadcast('set_background', {
         imageData: selectedImageData,
-        fileName: selectedImageName || null
+        fileName: selectedImageName || null,
+        vector: null
     });
-    activeBackgroundImage = selectedImageData;
     updateReferenceStatus('Image sent to your students.');
     showPushFeedback('Sent!');
 }
@@ -1195,6 +1205,7 @@ function clearReferenceImage(resetActive = false) {
 
     if (resetActive) {
         activeBackgroundImage = null;
+        activeBackgroundVectors = null;
         recordBackgroundChange(null, { name: null });
     }
 
@@ -1259,13 +1270,14 @@ function showPushFeedback(message) {
 }
 
 function sendBackgroundToStudent(username) {
-    if (!activeBackgroundImage || !username) {
+    if (!username || (!activeBackgroundImage && !activeBackgroundVectors)) {
         return;
     }
 
     safeSend('set_background', {
-        imageData: activeBackgroundImage,
-        target: username
+        imageData: activeBackgroundImage || null,
+        target: username,
+        vector: cloneBackgroundVectorDefinition(activeBackgroundVectors)
     });
 }
 
@@ -1292,6 +1304,7 @@ function clearAllStudentCanvases() {
     students.forEach((student, username) => {
         student.backgroundImageData = null;
         student.backgroundImageElement = null;
+        student.backgroundVectors = null;
         student.paths = [];
         drawStudentCanvas(student);
         student.updatedAt.textContent = 'Awaiting activity';
@@ -1360,47 +1373,29 @@ function drawStudentCanvas(student) {
         return;
     }
 
-    const resetTargets = () => {
+    const render = () => {
         targets.forEach(({ ctx, canvas }) => {
             resetCanvas(ctx, canvas);
-        });
-    };
-
-    const renderWithBackground = () => {
-        targets.forEach(({ ctx }) => {
-            drawStudentBackground(ctx, student.backgroundImageElement);
+            drawStudentBackground(ctx, student.backgroundImageElement, student.backgroundVectors);
             renderStudentPaths(ctx, student.paths);
         });
     };
 
-    const renderWithoutBackground = () => {
-        targets.forEach(({ ctx }) => {
-            renderStudentPaths(ctx, student.paths);
-        });
-    };
+    render();
 
-    resetTargets();
-
-    if (student.backgroundImageElement) {
-        if (student.backgroundImageElement.complete) {
-            renderWithBackground();
-        } else {
-            student.backgroundImageElement.onload = () => {
-                resetTargets();
-                renderWithBackground();
-                student.backgroundImageElement.onload = null;
-            };
-            student.backgroundImageElement.onerror = () => {
-                resetTargets();
-                renderWithoutBackground();
-                student.backgroundImageElement.onload = null;
-                student.backgroundImageElement.onerror = null;
-            };
-        }
-        return;
+    if (student.backgroundImageElement && !student.backgroundImageElement.complete) {
+        student.backgroundImageElement.onload = () => {
+            student.backgroundImageElement.onload = null;
+            student.backgroundImageElement.onerror = null;
+            render();
+        };
+        student.backgroundImageElement.onerror = () => {
+            student.backgroundImageElement.onload = null;
+            student.backgroundImageElement.onerror = null;
+            student.backgroundImageElement = null;
+            render();
+        };
     }
-
-    renderWithoutBackground();
 }
 
 function getStudentTargets(student) {
@@ -1542,25 +1537,608 @@ function studentClamp(value, min, max) {
     return Math.min(max, Math.max(min, value));
 }
 
-function drawStudentBackground(ctx, image) {
-    const canvasRatio = BASE_CANVAS_WIDTH / BASE_CANVAS_HEIGHT;
-    const imageRatio = image.width / image.height;
-
-    let drawWidth = BASE_CANVAS_WIDTH;
-    let drawHeight = BASE_CANVAS_HEIGHT;
-
-    if (imageRatio > canvasRatio) {
-        drawWidth = BASE_CANVAS_WIDTH;
-        drawHeight = BASE_CANVAS_WIDTH / imageRatio;
-    } else {
-        drawHeight = BASE_CANVAS_HEIGHT;
-        drawWidth = BASE_CANVAS_HEIGHT * imageRatio;
+function drawStudentBackground(ctx, image, vectorDefinition) {
+    if (!ctx) {
+        return;
     }
 
-    const offsetX = (BASE_CANVAS_WIDTH - drawWidth) / 2;
-    const offsetY = (BASE_CANVAS_HEIGHT - drawHeight) / 2;
+    if (image && image.width && image.height) {
+        const { drawWidth, drawHeight, offsetX, offsetY } = calculateContainDimensions(
+            image.width,
+            image.height,
+            BASE_CANVAS_WIDTH,
+            BASE_CANVAS_HEIGHT
+        );
 
-    ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
+        ctx.drawImage(image, offsetX, offsetY, drawWidth, drawHeight);
+    }
+
+    if (vectorDefinition) {
+        drawVectorDefinition(ctx, vectorDefinition, BASE_CANVAS_WIDTH, BASE_CANVAS_HEIGHT);
+    }
+}
+
+function drawVectorDefinition(ctx, definition, targetWidth, targetHeight) {
+    const normalised = normaliseBackgroundVectorDefinition(definition);
+    if (!normalised) {
+        return;
+    }
+
+    const { width, height, elements } = normalised;
+    if (!width || !height || elements.length === 0) {
+        return;
+    }
+
+    const { drawWidth, drawHeight, offsetX, offsetY } = calculateContainDimensions(
+        width,
+        height,
+        targetWidth,
+        targetHeight
+    );
+
+    const scaleX = drawWidth / width;
+    const scaleY = drawHeight / height;
+
+    ctx.save();
+    ctx.translate(offsetX, offsetY);
+    ctx.scale(scaleX, scaleY);
+
+    elements.forEach((element) => {
+        ctx.save();
+
+        const opacity = typeof element.opacity === 'number'
+            ? clampNumber(element.opacity, 0, 1)
+            : 1;
+        ctx.globalAlpha = opacity;
+
+        if (Array.isArray(element.dash) && element.dash.length > 0) {
+            ctx.setLineDash(element.dash);
+        } else {
+            ctx.setLineDash([]);
+        }
+
+        switch (element.type) {
+            case 'line':
+                ctx.beginPath();
+                ctx.lineCap = element.cap || 'butt';
+                ctx.lineJoin = element.join || 'miter';
+                ctx.lineWidth = element.strokeWidth || 1;
+                ctx.strokeStyle = element.stroke || '#000000';
+                ctx.moveTo(element.x1, element.y1);
+                ctx.lineTo(element.x2, element.y2);
+                ctx.stroke();
+                break;
+            case 'arrow':
+                ctx.beginPath();
+                ctx.lineCap = element.cap || 'butt';
+                ctx.lineJoin = element.join || 'miter';
+                ctx.lineWidth = element.strokeWidth || 1;
+                ctx.strokeStyle = element.stroke || '#000000';
+                ctx.moveTo(element.x1, element.y1);
+                ctx.lineTo(element.x2, element.y2);
+                ctx.stroke();
+                drawArrowHead(ctx, element);
+                break;
+            case 'rect':
+            case 'roundedRect': {
+                drawRoundedRectPath(ctx, element.x, element.y, element.width, element.height, element.radius || 0);
+                if (element.fill) {
+                    ctx.fillStyle = element.fill;
+                    ctx.fill();
+                }
+                if (element.stroke && element.strokeWidth > 0) {
+                    ctx.strokeStyle = element.stroke;
+                    ctx.lineWidth = element.strokeWidth;
+                    ctx.lineJoin = element.join || 'miter';
+                    ctx.stroke();
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        ctx.restore();
+    });
+
+    ctx.restore();
+}
+
+function calculateContainDimensions(sourceWidth, sourceHeight, targetWidth, targetHeight) {
+    if (!sourceWidth || !sourceHeight) {
+        return { drawWidth: 0, drawHeight: 0, offsetX: 0, offsetY: 0 };
+    }
+
+    const sourceRatio = sourceWidth / sourceHeight;
+    const targetRatio = targetWidth / targetHeight;
+
+    let drawWidth = targetWidth;
+    let drawHeight = targetHeight;
+
+    if (sourceRatio > targetRatio) {
+        drawHeight = targetWidth / sourceRatio;
+    } else {
+        drawWidth = targetHeight * sourceRatio;
+    }
+
+    const offsetX = (targetWidth - drawWidth) / 2;
+    const offsetY = (targetHeight - drawHeight) / 2;
+
+    return { drawWidth, drawHeight, offsetX, offsetY };
+}
+
+function drawRoundedRectPath(ctx, x, y, width, height, radius) {
+    const resolvedRadius = Math.max(0, Math.min(radius || 0, Math.min(width, height) / 2));
+
+    ctx.beginPath();
+    if (resolvedRadius === 0) {
+        ctx.rect(x, y, width, height);
+        return;
+    }
+
+    ctx.moveTo(x + resolvedRadius, y);
+    ctx.lineTo(x + width - resolvedRadius, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + resolvedRadius);
+    ctx.lineTo(x + width, y + height - resolvedRadius);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - resolvedRadius, y + height);
+    ctx.lineTo(x + resolvedRadius, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - resolvedRadius);
+    ctx.lineTo(x, y + resolvedRadius);
+    ctx.quadraticCurveTo(x, y, x + resolvedRadius, y);
+    ctx.closePath();
+}
+
+function drawArrowHead(ctx, element) {
+    const headLength = element.headLength || Math.max(12, (element.strokeWidth || 1) * 3);
+    const headWidth = element.headWidth || headLength * 0.6;
+    const angle = Math.atan2(element.y2 - element.y1, element.x2 - element.x1);
+
+    const sin = Math.sin(angle);
+    const cos = Math.cos(angle);
+
+    const leftX = element.x2 - headLength * cos + (headWidth / 2) * sin;
+    const leftY = element.y2 - headLength * sin - (headWidth / 2) * cos;
+    const rightX = element.x2 - headLength * cos - (headWidth / 2) * sin;
+    const rightY = element.y2 - headLength * sin + (headWidth / 2) * cos;
+
+    ctx.beginPath();
+    ctx.moveTo(element.x2, element.y2);
+    ctx.lineTo(leftX, leftY);
+    ctx.lineTo(rightX, rightY);
+    ctx.closePath();
+    ctx.fillStyle = element.fill || element.stroke || '#000000';
+    ctx.fill();
+}
+
+function cloneBackgroundVectorDefinition(definition) {
+    const normalised = normaliseBackgroundVectorDefinition(definition);
+    if (!normalised) {
+        return null;
+    }
+
+    return {
+        width: normalised.width,
+        height: normalised.height,
+        elements: normalised.elements.map((element) => ({
+            ...element,
+            dash: Array.isArray(element.dash) ? [...element.dash] : undefined
+        }))
+    };
+}
+
+function normaliseBackgroundVectorDefinition(raw) {
+    if (!raw || typeof raw !== 'object') {
+        return null;
+    }
+
+    const width = toPositiveNumber(
+        raw.width ?? raw.viewBoxWidth ?? (raw.viewBox && raw.viewBox.width)
+    );
+    const height = toPositiveNumber(
+        raw.height ?? raw.viewBoxHeight ?? (raw.viewBox && raw.viewBox.height)
+    );
+
+    if (!width || !height) {
+        return null;
+    }
+
+    const sourceElements = Array.isArray(raw.elements) ? raw.elements : [];
+    const elements = sourceElements.reduce((accumulator, element) => {
+        const normalisedElement = normaliseVectorElement(element);
+        if (normalisedElement) {
+            accumulator.push(normalisedElement);
+        }
+        return accumulator;
+    }, []);
+
+    if (elements.length === 0) {
+        return null;
+    }
+
+    return { width, height, elements };
+}
+
+function normaliseVectorElement(element) {
+    if (!element || typeof element !== 'object') {
+        return null;
+    }
+
+    const type = typeof element.type === 'string' ? element.type : '';
+
+    if (type === 'line' || type === 'arrow') {
+        const x1 = toFiniteNumber(element.x1);
+        const y1 = toFiniteNumber(element.y1);
+        const x2 = toFiniteNumber(element.x2);
+        const y2 = toFiniteNumber(element.y2);
+
+        if (x1 === null || y1 === null || x2 === null || y2 === null) {
+            return null;
+        }
+
+        const strokeWidth = toPositiveNumber(element.strokeWidth, 1);
+        const dash = normaliseDashArray(element.dash);
+        const opacity = normaliseOpacity(element.opacity);
+        const stroke = normaliseColor(element.stroke) || '#000000';
+
+        const base = {
+            type,
+            x1,
+            y1,
+            x2,
+            y2,
+            stroke,
+            strokeWidth,
+            cap: normaliseLineCap(element.cap),
+            join: normaliseLineJoin(element.join),
+            dash,
+            opacity
+        };
+
+        if (type === 'arrow') {
+            return {
+                ...base,
+                headLength: toPositiveNumber(element.headLength, Math.max(12, strokeWidth * 3)),
+                headWidth: toPositiveNumber(element.headWidth, Math.max(8, strokeWidth * 2)),
+                fill: normaliseColor(element.fill) || stroke
+            };
+        }
+
+        return base;
+    }
+
+    if (type === 'rect' || type === 'roundedRect') {
+        const x = toFiniteNumber(element.x);
+        const y = toFiniteNumber(element.y);
+        const width = toPositiveNumber(element.width);
+        const height = toPositiveNumber(element.height);
+
+        if (x === null || y === null || !width || !height) {
+            return null;
+        }
+
+        const strokeWidthValue = toPositiveNumber(element.strokeWidth, null);
+
+        return {
+            type,
+            x,
+            y,
+            width,
+            height,
+            radius: type === 'roundedRect'
+                ? toNonNegativeNumber(element.radius, 0)
+                : 0,
+            stroke: normaliseColor(element.stroke),
+            strokeWidth: strokeWidthValue ?? 0,
+            fill: normaliseFill(element.fill),
+            join: normaliseLineJoin(element.join),
+            opacity: normaliseOpacity(element.opacity)
+        };
+    }
+
+    return null;
+}
+
+function normaliseLineCap(value) {
+    if (typeof value !== 'string') {
+        return 'butt';
+    }
+
+    const cap = value.toLowerCase();
+    return cap === 'round' || cap === 'square' ? cap : 'butt';
+}
+
+function normaliseLineJoin(value) {
+    if (typeof value !== 'string') {
+        return 'miter';
+    }
+
+    const join = value.toLowerCase();
+    return join === 'round' || join === 'bevel' ? join : 'miter';
+}
+
+function normaliseDashArray(value) {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+
+    const dash = value
+        .map((entry) => toPositiveNumber(entry, null))
+        .filter((entry) => entry !== null);
+
+    return dash.length > 0 ? dash : undefined;
+}
+
+function normaliseOpacity(value) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        return 1;
+    }
+
+    return clampNumber(value, 0, 1);
+}
+
+function normaliseColor(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length === 0 || trimmed.toLowerCase() === 'none'
+        ? null
+        : trimmed;
+}
+
+function normaliseFill(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0 || trimmed.toLowerCase() === 'none') {
+        return null;
+    }
+    return trimmed;
+}
+
+function toFiniteNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function toPositiveNumber(value, fallback = null) {
+    const numeric = typeof value === 'number' && Number.isFinite(value) ? value : null;
+    if (numeric === null || numeric <= 0) {
+        return fallback && Number.isFinite(fallback) && fallback > 0 ? fallback : null;
+    }
+    return numeric;
+}
+
+function toNonNegativeNumber(value, fallback = 0) {
+    const numeric = typeof value === 'number' && Number.isFinite(value) ? value : null;
+    if (numeric === null || numeric < 0) {
+        return fallback >= 0 ? fallback : 0;
+    }
+    return numeric;
+}
+
+function createChineseVectorData() {
+    const elements = [
+        {
+            type: 'roundedRect',
+            x: 48,
+            y: 48,
+            width: 928,
+            height: 928,
+            radius: 64,
+            stroke: '#8fbf68',
+            strokeWidth: 32,
+            fill: null
+        },
+        {
+            type: 'roundedRect',
+            x: 80,
+            y: 80,
+            width: 864,
+            height: 864,
+            radius: 48,
+            stroke: '#cfe5b6',
+            strokeWidth: 12,
+            fill: null
+        },
+        {
+            type: 'line',
+            x1: 80,
+            y1: 512,
+            x2: 944,
+            y2: 512,
+            stroke: '#8fbf68',
+            strokeWidth: 18,
+            dash: [2, 26],
+            cap: 'round',
+            opacity: 0.9
+        },
+        {
+            type: 'line',
+            x1: 512,
+            y1: 80,
+            x2: 512,
+            y2: 944,
+            stroke: '#8fbf68',
+            strokeWidth: 18,
+            dash: [2, 26],
+            cap: 'round',
+            opacity: 0.9
+        }
+    ];
+
+    return cloneBackgroundVectorDefinition({
+        width: 1024,
+        height: 1024,
+        elements
+    });
+}
+
+function createGraphCrossVectorData() {
+    const elements = [
+        {
+            type: 'rect',
+            x: 64,
+            y: 64,
+            width: 896,
+            height: 896,
+            stroke: '#d1d5db',
+            strokeWidth: 6,
+            fill: '#ffffff'
+        }
+    ];
+
+    const gridColor = '#e2e8f0';
+    const gridStroke = 2;
+    const gridLines = [192, 320, 448, 576, 704, 832];
+
+    gridLines.forEach((y) => {
+        elements.push({
+            type: 'line',
+            x1: 64,
+            y1: y,
+            x2: 960,
+            y2: y,
+            stroke: gridColor,
+            strokeWidth: gridStroke
+        });
+    });
+
+    gridLines.forEach((x) => {
+        elements.push({
+            type: 'line',
+            x1: x,
+            y1: 64,
+            x2: x,
+            y2: 960,
+            stroke: gridColor,
+            strokeWidth: gridStroke
+        });
+    });
+
+    const axisStroke = '#4b5563';
+    const axisWidth = 8;
+    const headLength = 36;
+    const headWidth = 24;
+
+    elements.push({
+        type: 'arrow',
+        x1: 80,
+        y1: 512,
+        x2: 944,
+        y2: 512,
+        stroke: axisStroke,
+        strokeWidth: axisWidth,
+        cap: 'round',
+        headLength,
+        headWidth,
+        fill: axisStroke
+    });
+
+    elements.push({
+        type: 'arrow',
+        x1: 512,
+        y1: 944,
+        x2: 512,
+        y2: 80,
+        stroke: axisStroke,
+        strokeWidth: axisWidth,
+        cap: 'round',
+        headLength,
+        headWidth,
+        fill: axisStroke
+    });
+
+    return cloneBackgroundVectorDefinition({
+        width: 1024,
+        height: 1024,
+        elements
+    });
+}
+
+function createGraphCornerVectorData() {
+    const elements = [
+        {
+            type: 'rect',
+            x: 64,
+            y: 64,
+            width: 896,
+            height: 896,
+            stroke: '#d1d5db',
+            strokeWidth: 6,
+            fill: '#ffffff'
+        }
+    ];
+
+    const gridColor = '#e2e8f0';
+    const gridStroke = 2;
+    const horizontalLines = [832, 704, 576, 448, 320, 192];
+    const verticalLines = [192, 320, 448, 576, 704, 832];
+
+    horizontalLines.forEach((y) => {
+        elements.push({
+            type: 'line',
+            x1: 64,
+            y1: y,
+            x2: 960,
+            y2: y,
+            stroke: gridColor,
+            strokeWidth: gridStroke
+        });
+    });
+
+    verticalLines.forEach((x) => {
+        elements.push({
+            type: 'line',
+            x1: x,
+            y1: 64,
+            x2: x,
+            y2: 960,
+            stroke: gridColor,
+            strokeWidth: gridStroke
+        });
+    });
+
+    const axisStroke = '#334155';
+    const axisWidth = 10;
+    const headLength = 40;
+    const headWidth = 26;
+
+    elements.push({
+        type: 'arrow',
+        x1: 96,
+        y1: 896,
+        x2: 912,
+        y2: 896,
+        stroke: axisStroke,
+        strokeWidth: axisWidth,
+        cap: 'round',
+        headLength,
+        headWidth,
+        fill: axisStroke
+    });
+
+    elements.push({
+        type: 'arrow',
+        x1: 96,
+        y1: 896,
+        x2: 96,
+        y2: 112,
+        stroke: axisStroke,
+        strokeWidth: axisWidth,
+        cap: 'round',
+        headLength,
+        headWidth,
+        fill: axisStroke
+    });
+
+    return cloneBackgroundVectorDefinition({
+        width: 1024,
+        height: 1024,
+        elements
+    });
 }
 
 function loadImage(dataUrl) {


### PR DESCRIPTION
## Summary
- package preset background modes with reusable vector guide definitions
- broadcast background vector data alongside images so student canvases render complete guides
- update teacher previews and student state management to draw the synced vector overlays reliably

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d8b2981d288327ac0f05a8152598fb