### PR TITLE
Align student canvas with teacher canvas aspect ratio

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -1170,6 +1170,25 @@ function resizeCanvas() {
         return;
     }
 
+    const container = studentCanvasSurface || canvas.parentElement;
+    const containerRect = container?.getBoundingClientRect?.();
+    if (!containerRect || !containerRect.width || !containerRect.height) {
+        return;
+    }
+
+    const { drawWidth, drawHeight } = calculateContainDimensions(
+        BASE_CANVAS_WIDTH,
+        BASE_CANVAS_HEIGHT,
+        containerRect.width,
+        containerRect.height
+    );
+
+    const displayWidth = Math.max(1, drawWidth);
+    const displayHeight = Math.max(1, drawHeight);
+
+    canvas.style.width = `${displayWidth}px`;
+    canvas.style.height = `${displayHeight}px`;
+
     const rect = canvas.getBoundingClientRect();
     if (!rect.width || !rect.height) {
         return;

--- a/public/styles.css
+++ b/public/styles.css
@@ -2147,12 +2147,13 @@ body.student-shell * {
     position: relative;
     min-height: 0;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .student-canvas__surface canvas {
     display: block;
-    width: 100%;
-    height: 100%;
     touch-action: none;
     background: #ffffff;
 }


### PR DESCRIPTION
## Summary
- resize the student canvas using 4:3 contain math before applying device-pixel ratio scaling
- center the canvas within its container so background images and strokes line up with teacher previews

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d8bf1b70c48327af84e127804fef5e