### PR TITLE
Letterbox student canvas when backgrounds are active

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1947,6 +1947,16 @@ body.student-shell * {
     justify-content: stretch;
 }
 
+.student-canvas__surface--letterboxed {
+    background: #000000;
+    align-items: center;
+    justify-content: center;
+}
+
+.student-canvas__surface--letterboxed canvas {
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.2);
+}
+
 .student-canvas__surface canvas {
     display: block;
     touch-action: none;


### PR DESCRIPTION
## Summary
- constrain the student canvas to the base 4:3 aspect ratio whenever a background image or preset is active
- toggle a letterboxed presentation that centers the drawable area and darkens the surrounding surface
- keep the canvas full-width in normal drawing mode by clearing the constraints when backgrounds are removed

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68d90472d05883279d13009d7249e84b