### PR TITLE
Hide photo preview image until an upload is ready

### DIFF
--- a/public/js/teacher.js
+++ b/public/js/teacher.js
@@ -3031,12 +3031,18 @@ function updateReferencePreview(imageData, altText = 'Selected reference preview
         referencePreviewImage.removeAttribute('src');
         referencePreviewImage.alt = '';
         referencePreviewImage.hidden = true;
+        if (referencePreview) {
+            referencePreview.classList.remove('has-image');
+        }
         if (referencePreviewPlaceholder) {
             referencePreviewPlaceholder.hidden = false;
         }
         return;
     }
 
+    if (referencePreview) {
+        referencePreview.classList.add('has-image');
+    }
     referencePreviewImage.hidden = false;
     referencePreviewImage.src = imageData;
     referencePreviewImage.alt = altText;

--- a/public/styles.css
+++ b/public/styles.css
@@ -568,6 +568,10 @@ input[type="range"]::-moz-range-thumb {
     border-radius: 20px;
 }
 
+.mode-panel__preview--image:not(.has-image) img {
+    display: none;
+}
+
 .image-preview__placeholder {
     display: grid;
     place-items: center;


### PR DESCRIPTION
## Summary
- add a guard class when reference preview image is empty so the container stays in placeholder mode
- hide the preview <img> with CSS until a real image source is available

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9682297788327be08a18e2ae511b5