### PR TITLE
Fix pen size popovers and ensure teacher modal renders student canvas

### DIFF
--- a/public/js/student.js
+++ b/public/js/student.js
@@ -506,7 +506,7 @@ function openBrushSizePopover(options = {}) {
     isBrushPopoverOpen = true;
     brushPopoverReturnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
 
-    brushSizePopover.hidden = false;
+    brushSizePopover.removeAttribute('hidden');
     brushSizePopover.classList.remove('hidden');
     brushSizePopover.classList.remove('is-visible');
     brushSizePopover.dataset.placement = '';
@@ -537,7 +537,7 @@ function closeBrushSizePopover() {
 
     isBrushPopoverOpen = false;
     brushSizePopover.classList.remove('is-visible');
-    brushSizePopover.style.visibility = '';
+    brushSizePopover.style.visibility = 'hidden';
     brushSizePopover.dataset.placement = '';
     brushSizeButton.setAttribute('aria-expanded', 'false');
 
@@ -546,7 +546,7 @@ function closeBrushSizePopover() {
     window.removeEventListener('resize', handleBrushSizeViewportChange, true);
     window.removeEventListener('scroll', handleBrushSizeViewportChange, true);
 
-    brushSizePopover.hidden = true;
+    brushSizePopover.setAttribute('hidden', '');
     brushSizePopover.classList.add('hidden');
 
     if (brushPopoverReturnFocus && document.contains(brushPopoverReturnFocus)) {


### PR DESCRIPTION
## Summary
- allow the student and teacher pen size popovers to reliably open and close by explicitly toggling their hidden state
- keep the teacher pen size control available when a student is not attached and tidy up the popover visibility handling
- fall back to copying the student card canvas into the modal preview when no vector data is available so the teacher still sees drawings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db993786648327a521a390ed37978c